### PR TITLE
Makes the json schema match all files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"

--- a/src/service.ts
+++ b/src/service.ts
@@ -35,7 +35,7 @@ export const getLanguageService: GetLanguageServiceFunc = function(params) {
         schemas: [
             {
                 uri: 'asl',
-                fileMatch: ['*.asl', '*.asl.json'],
+                fileMatch: ['*'],
                 schema: aslSchema
             }
         ]


### PR DESCRIPTION
*Issue #, if available:*
Json schema would not work on any other files than those that matched *.asl or *.asl.json . We need to be able to match all the files in case they are marked as asl. 

*Description of changes:*
I changed the glob pattern for fileMatch to match all  the files. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
