### PR TITLE
Fixes type errors for completions and validations

### DIFF
--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -8,12 +8,14 @@ import {
     CompletionItem,
     CompletionItemKind,
     InsertTextFormat,
-    ObjectASTNode} from 'vscode-json-languageservice'
+    ObjectASTNode,
+    PropertyASTNode} from 'vscode-json-languageservice'
 
 import {
     findPropChildByName,
     insideStateNode,
     isChildOfStates,
+    isObjectNode,
 } from '../utils/astUtilityFunctions'
 
 import errorHandlingSnippetsRaw from '../snippets/error_handling.json'
@@ -42,7 +44,11 @@ function parseSnippetsFromJson(json: Snippet[]): CompletionItem[] {
 }
 
 function doesStateSupportErrorHandling(node: ASTNode): boolean {
-    const typeNode = findPropChildByName(node as ObjectASTNode, 'Type')
+    let typeNode: PropertyASTNode
+
+    if(isObjectNode(node)) {
+        typeNode = findPropChildByName(node, 'Type')
+    }
 
     return ERROR_HANDLING_STATES.includes(typeNode?.valueNode?.value as string)
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -13,6 +13,7 @@ import aslSchema from './json-schema/bundled.json';
 
 import {
     ASTTree,
+    isObjectNode
 } from './utils/astUtilityFunctions'
 
 import completeAsl from './completion/completeAsl'
@@ -55,7 +56,7 @@ export const getLanguageService: GetLanguageServiceFunc = function(params) {
 
         const rootNode = (jsonDocument as ASTTree).root
 
-        if (rootNode) {
+        if (rootNode && isObjectNode(rootNode)) {
             const aslDiagnostics = validateStates(rootNode, document)
 
             return diagnostics.concat(aslDiagnostics)

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -534,7 +534,7 @@ const documentParallelCatchTemplateInvalidNext = `{
   }
 }`
 
-interface TestValidationOptions {
+export interface TestValidationOptions {
     json: string,
     diagnostics: {
         message: string,
@@ -544,12 +544,17 @@ interface TestValidationOptions {
     filterMessages?: string[]
 }
 
-async function testValidations(options: TestValidationOptions) {
-    const { json, diagnostics, filterMessages } = options
+async function getValidations(json: string) {
     const { textDoc, jsonDoc } = toDocument(json);
     const ls = getLanguageService({});
 
-    let res = await ls.doValidation(textDoc, jsonDoc)
+    return await ls.doValidation(textDoc, jsonDoc)
+}
+
+async function testValidations(options: TestValidationOptions) {
+    const { json, diagnostics, filterMessages } = options
+
+    let res = await getValidations(json)
 
     res = res.filter(diagnostic => {
         if (filterMessages && filterMessages.find(message => message === diagnostic.message) ) {
@@ -577,6 +582,19 @@ async function testValidations(options: TestValidationOptions) {
 }
 
 suite('ASL context-aware validation', () => {
+    suite('Invalid JSON Input', () => {
+      test("Empty string doesn't throw errors", async () => {
+        await getValidations('')
+      })
+
+      test("[] string doesn't throw type errors", async () => {
+        await assert.doesNotReject(
+          getValidations('[]'),
+          TypeError
+        )
+      })
+    })
+
     suite('StartAt', () => {
         test('Shows Diagnostic for state name that doesn\'t exist', async () => {
             await testValidations({

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -6,7 +6,7 @@
 import { ArrayASTNode, ASTNode, JSONDocument, ObjectASTNode, PropertyASTNode, StringASTNode } from 'vscode-json-languageservice'
 
 export interface ASTTree extends JSONDocument {
-    root?: ObjectASTNode | null
+    root?: ASTNode
 }
 
 export function isStringNode(node: ASTNode): node is StringASTNode {


### PR DESCRIPTION
*Issue #, if available:*
Type errors on validating empty document with disallowed characters or on completions in certain places.

*Description of changes:*
Completion errors and validation errors were caused by incorrect type casting to ObjectASTNode. I replaced type casting with a type guards. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
