### PR TITLE
Fixes type error when choice default missing

### DIFF
--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -675,3 +675,23 @@ export const documentChoiceInvalidDefault = `{
       }
   }
 }`
+
+export const documentChoiceNoDefault = `{
+    "StartAt": "ChoiceState",
+    "States": {
+        "ChoiceState": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.foo",
+                    "NumericEquals": 1,
+                    "Next": "FirstMatchState"
+                }
+            ]
+        },
+        "FirstMatchState": {
+            "Type": "Pass",
+            "End": true
+        }
+    }
+}`

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -11,6 +11,7 @@ import { MESSAGES } from '../validation/validateStates'
 import {
   documentChoiceInvalidDefault,
   documentChoiceInvalidNext,
+  documentChoiceNoDefault,
   documentChoiceValidDefault,
   documentChoiceValidNext,
   documentInvalidNext,
@@ -116,6 +117,13 @@ suite('ASL context-aware validation', () => {
         test('Doesn\'t show Diagnostic for valid state name', async () => {
             await testValidations({
                 json: documentChoiceValidDefault,
+                diagnostics: []
+            })
+        })
+
+        test('Doesn\'t show Diagnostic when default property is absent', async () => {
+            await testValidations({
+                json: documentChoiceNoDefault,
                 diagnostics: []
             })
         })

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+/* tslint:disable:cyclomatic-complexity */
+
 import {
     Diagnostic,
     DiagnosticSeverity,
@@ -180,13 +182,12 @@ export default function validateStates(rootNode: ObjectASTNode, document: TextDo
 
                         case 'Choice': {
                             const defaultNode = findPropChildByName(oneStateValueNode, 'Default')
+                            const name = defaultNode?.valueNode?.value
                             const defaultStateDiagnostic = stateNameExistsInPropNode(defaultNode, stateNames, document, MESSAGES.INVALID_DEFAULT)
 
                             if (defaultStateDiagnostic) {
                                 diagnostics.push(defaultStateDiagnostic)
-                            } else {
-                                const name = defaultNode.valueNode.value as string
-
+                            } else if (typeof name === 'string') {
                                 reachedStates[name] = true
                             }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-toolkit-vscode/issues/1030

*Description of changes:*
I added checks for existence of `valueNode`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
