### PR TITLE
Implements validation of additional properties

### DIFF
--- a/src/constants/diagnosticStrings.ts
+++ b/src/constants/diagnosticStrings.ts
@@ -9,6 +9,6 @@ export const MESSAGES = {
     INVALID_START_AT: 'The value of "StartAt" property must be the name of an existing state.',
     UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
     NO_TERMINAL_STATE: 'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
-    INVALID_PROPERTY_NAME: 'The property name is invalid',
-    MUTUALLY_EXCLUSIVE_PROPERTIES: 'The following properties are mutually exclusive: '
+    INVALID_PROPERTY_NAME: 'Field is not supported.',
+    MUTUALLY_EXCLUSIVE_PROPERTIES: 'Each choice rule can only have one comparison type.'
 } as const

--- a/src/constants/diagnosticStrings.ts
+++ b/src/constants/diagnosticStrings.ts
@@ -10,5 +10,5 @@ export const MESSAGES = {
     UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
     NO_TERMINAL_STATE: 'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
     INVALID_PROPERTY_NAME: 'Field is not supported.',
-    MUTUALLY_EXCLUSIVE_PROPERTIES: 'Each choice rule can only have one comparison type.'
+    MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.'
 } as const

--- a/src/constants/diagnosticStrings.ts
+++ b/src/constants/diagnosticStrings.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+export const MESSAGES = {
+    INVALID_NEXT: 'The value of "Next" property must be the name of an existing state.',
+    INVALID_DEFAULT: 'The value of "Default" property must be the name of an existing state.',
+    INVALID_START_AT: 'The value of "StartAt" property must be the name of an existing state.',
+    UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
+    NO_TERMINAL_STATE: 'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
+    INVALID_PROPERTY_NAME: 'The property name is invalid',
+    MUTUALLY_EXCLUSIVE_PROPERTIES: 'The following properties are mutually exclusive: '
+} as const

--- a/src/service.ts
+++ b/src/service.ts
@@ -44,7 +44,7 @@ export const getLanguageService: GetLanguageServiceFunc = function(params) {
 
     languageService.doValidation = async function(document, jsonDocument, documentSettings) {
         // vscode-json-languageservice will always set severity as warning for JSONSchema validation
-        // there is no option to configure this behaviour so severity needs to be overwritten as error
+        // there is no option to configure this behavior so severity needs to be overwritten as error
         const diagnostics = (await doValidation(document, jsonDocument, documentSettings)).map(diagnostic => {
             // Non JSON Schema validation will have source: 'asl'
             if (diagnostic.source !== 'asl') {
@@ -57,7 +57,7 @@ export const getLanguageService: GetLanguageServiceFunc = function(params) {
         const rootNode = (jsonDocument as ASTTree).root
 
         if (rootNode && isObjectNode(rootNode)) {
-            const aslDiagnostics = validateStates(rootNode, document)
+            const aslDiagnostics = validateStates(rootNode, document, true)
 
             return diagnostics.concat(aslDiagnostics)
         }

--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -722,3 +722,164 @@ export const documentChoiceDefaultBeforeChoice = `{
       }
   }
 }`
+
+export const documentInvalidPropertiesState = `{
+  "StartAt": "FirstState",
+  "States": {
+      "FirstState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME",
+          "Next": "ChoiceState",
+          "SomethingInvalid1": "dddd",
+          "SomethingInvalid2": "eeee"
+      },
+      "ChoiceState": {
+          "Type": "Choice",
+          "Choices": [
+              {
+                  "Variable": "$.foo",
+                  "NumericEquals": 1,
+                  "Next": "FirstMatchState"
+              }
+          ],
+          "Default": "DefaultState"
+      },
+      "FirstMatchState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch",
+          "Next": "NextState"
+      },
+      "DefaultState": {
+          "Type": "Fail",
+          "Error": "DefaultStateError",
+          "Cause": "No Matches!"
+      },
+      "NextState": {
+          "Type": "Pass",
+          "End": true
+      }
+  }
+}`
+
+export const documentInvalidPropertiesCatch = `{
+    "StartAt": "HelloWorld",
+    "States": {
+        "HelloWorld": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME",
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "CustomError"
+                    ],
+                    "Next": "CustomErrorFallback",
+                    "OneInvalid": "something"
+                },
+                {
+                    "ErrorEquals": [
+                        "States.TaskFailed"
+                    ],
+                    "Next": "ReservedTypeFallback",
+                    "TwoInvalid": "something",
+                    "ThreeInvalid": "something"
+                },
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "CatchAllFallback"
+                }
+            ],
+            "End": true
+        },
+        "CustomErrorFallback": {
+            "Type": "Pass",
+            "Result": "This is a fallback from a custom lambda function exception",
+            "End": true
+        },
+        "ReservedTypeFallback": {
+            "Type": "Pass",
+            "Result": "This is a fallback from a reserved error code",
+            "End": true
+        },
+        "CatchAllFallback": {
+            "Type": "Pass",
+            "Result": "This is a fallback from a reserved error code",
+            "End": true
+        }
+    }
+}`
+
+export const documentInvalidPropertiesChoices = `{
+  "Comment": "An example of the Amazon States Language using a choice state.",
+  "StartAt": "FirstState",
+  "States": {
+      "FirstState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME",
+          "Next": "ChoiceState"
+      },
+      "ChoiceState": {
+          "Type": "Choice",
+          "Choices": [
+              {
+                  "Not": {
+                      "Variable": "$.foo",
+                      "StringEquals": "blabla",
+                      "NumericGreaterThanEquals": 20,
+                      "FirstInvalidProp": {}
+                  },
+                  "Next": "FirstMatchState"
+              },
+              {
+
+                  "SecondInvalidProp": {},
+                  "And": [
+                      {
+                          "Not": {
+                              "Variable": "$.foo",
+                              "StringEquals": "blabla",
+                              "ThirdInvalidProp": {}
+                          }
+                      },
+                      {
+                          "Or": [
+                              {
+                                  "Variable": "$.value",
+                                  "NumericGreaterThanEquals": 20,
+                                  "FourthInvalidProp": {}
+                              },
+                              {
+                                  "Variable": "$.value",
+                                  "NumericLessThan": 30
+                              }
+                          ]
+                      }
+                  ],
+                  "Next": "SecondMatchState"
+              }
+          ],
+          "Default": "DefaultState"
+      },
+      "FirstMatchState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch",
+          "Next": "NextState"
+      },
+      "SecondMatchState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:OnSecondMatch",
+          "Next": "NextState"
+      },
+      "DefaultState": {
+          "Type": "Fail",
+          "Error": "DefaultStateError",
+          "Cause": "No Matches!"
+      },
+      "NextState": {
+          "Type": "Task",
+          "Resource": "arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME",
+          "End": true
+      }
+  }
+}`

--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -839,7 +839,8 @@ export const documentInvalidPropertiesChoices = `{
                           "Not": {
                               "Variable": "$.foo",
                               "StringEquals": "blabla",
-                              "ThirdInvalidProp": {}
+                              "ThirdInvalidProp": {},
+                              "Next": "FirstMatchState"
                           }
                       },
                       {
@@ -847,13 +848,19 @@ export const documentInvalidPropertiesChoices = `{
                               {
                                   "Variable": "$.value",
                                   "NumericGreaterThanEquals": 20,
-                                  "FourthInvalidProp": {}
+                                  "FourthInvalidProp": {},
+                                  "Next": "FirstMatchState"
                               },
                               {
                                   "Variable": "$.value",
                                   "NumericLessThan": 30
                               }
                           ]
+                      },
+                      {
+                        "Variable": "$.foo",
+                        "NumericGreaterThanEquals": 20,
+                        "Next": "SecondMatchState"
                       }
                   ],
                   "Next": "SecondMatchState"

--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -883,3 +883,43 @@ export const documentInvalidPropertiesChoices = `{
       }
   }
 }`
+
+export const documentInvalidPropertiesRoot = `{
+  "StartAt": "Succeed",
+  "TimeoutSeconds": 3,
+  "Version": "1.0",
+  "Comment": "It's a test",
+  "NewTopLevelField": "This field is not supported",
+  "States": {
+      "Succeed": {
+          "Type": "Succeed"
+      }
+  }
+}`
+
+export const documentInvalidPropertiesRootNested = `{
+  "StartAt": "Map",
+  "States": {
+      "Map": {
+          "Type": "Map",
+          "ItemsPath": "$.array",
+          "Next": "Final State",
+          "Iterator": {
+              "StartAt": "Pass",
+              "Comment": "Nested comment",
+              "InvalidProp": "This is invalid",
+              "States": {
+                  "Pass": {
+                      "Type": "Pass",
+                      "Result": "Done!",
+                      "End": true
+                  }
+              }
+          }
+      },
+      "Final State": {
+          "Type": "Pass",
+          "End": true
+      }
+  }
+}`

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -433,12 +433,12 @@ suite('ASL context-aware validation', () => {
                         end: [17, 40]
                     },
                     {
-                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES,
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES,
                         start: [15, 22],
                         end: [15, 36]
                     },
                     {
-                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES,
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES,
                         start: [16, 22],
                         end: [16, 48]
                     },

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -19,6 +19,8 @@ import {
   documentInvalidNextNested,
   documentInvalidPropertiesCatch,
   documentInvalidPropertiesChoices,
+  documentInvalidPropertiesRoot,
+  documentInvalidPropertiesRootNested,
   documentInvalidPropertiesState,
   documentNestedNoTerminalState,
   documentNestedUnreachableState,
@@ -36,6 +38,8 @@ import {
 } from './json-strings/validationStrings'
 
 import { toDocument } from './utils/testUtilities'
+
+const JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG = 'Matches multiple schemas when only one must validate.'
 
 export interface TestValidationOptions {
     json: string,
@@ -429,12 +433,12 @@ suite('ASL context-aware validation', () => {
                         end: [17, 40]
                     },
                     {
-                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES + 'StringEquals, NumericGreaterThanEquals',
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES,
                         start: [15, 22],
                         end: [15, 36]
                     },
                     {
-                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES + 'StringEquals, NumericGreaterThanEquals',
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES,
                         start: [16, 22],
                         end: [16, 48]
                     },
@@ -454,7 +458,35 @@ suite('ASL context-aware validation', () => {
                         end: [37, 53]
                     },
                 ],
-                filterMessages: [MESSAGES.UNREACHABLE_STATE, 'Matches multiple schemas when only one must validate.']
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG]
+
+            })
+
+        })
+
+        test('Shows diagnostics for additional invalid properties within root of state machine', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesRoot,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [5, 2],
+                        end: [5, 20]
+                    }
+                ]
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within root of nested state machine', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesRootNested,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [10, 14],
+                        end: [10, 27]
+                    }
+                ]
             })
         })
     })

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -5,8 +5,8 @@
 
 import * as assert from 'assert';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
+import { MESSAGES } from '../constants/diagnosticStrings'
 import { getLanguageService, Position, Range } from '../service'
-import { MESSAGES } from '../validation/validateStates'
 
 import {
   documentChoiceDefaultBeforeChoice,
@@ -17,6 +17,9 @@ import {
   documentChoiceValidNext,
   documentInvalidNext,
   documentInvalidNextNested,
+  documentInvalidPropertiesCatch,
+  documentInvalidPropertiesChoices,
+  documentInvalidPropertiesState,
   documentNestedNoTerminalState,
   documentNestedUnreachableState,
   documentNoTerminalState,
@@ -370,5 +373,89 @@ suite('ASL context-aware validation', () => {
             filterMessages: [MESSAGES.UNREACHABLE_STATE]
         })
       })
+    })
+
+    suite('Additional properties that are not valid', async () => {
+        test('Shows diagnostics for additional invalid properties of a given state', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [7, 10],
+                        end: [7, 29]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [8, 10],
+                        end: [8, 29]
+                    }
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE]
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within Catch block', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesCatch,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [12, 20],
+                        end: [12, 32]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [19, 20],
+                        end: [19, 32]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [20, 20],
+                        end: [20, 34]
+                    }
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE]
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within Choice state', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesChoices,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [17, 22],
+                        end: [17, 40]
+                    },
+                    {
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES + 'StringEquals, NumericGreaterThanEquals',
+                        start: [15, 22],
+                        end: [15, 36]
+                    },
+                    {
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES + 'StringEquals, NumericGreaterThanEquals',
+                        start: [16, 22],
+                        end: [16, 48]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [23, 18],
+                        end: [23, 37]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [29, 30],
+                        end: [29, 48]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [37, 34],
+                        end: [37, 53]
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, 'Matches multiple schemas when only one must validate.']
+            })
+        })
     })
 })

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -454,8 +454,23 @@ suite('ASL context-aware validation', () => {
                     },
                     {
                         message: MESSAGES.INVALID_PROPERTY_NAME,
-                        start: [37, 34],
-                        end: [37, 53]
+                        start: [30, 30],
+                        end: [30, 36]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [38, 34],
+                        end: [38, 53]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [39, 34],
+                        end: [39, 40]
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [50, 24],
+                        end: [50, 30]
                     },
                 ],
                 filterMessages: [MESSAGES.UNREACHABLE_STATE, JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG]

--- a/src/validation/utils/getPropertyNodeDiagnostic.ts
+++ b/src/validation/utils/getPropertyNodeDiagnostic.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+    Diagnostic,
+    DiagnosticSeverity,
+    PropertyASTNode,
+    Range,
+    TextDocument,
+} from 'vscode-json-languageservice'
+
+export default function getPropertyNodeDiagnostic(propNode: PropertyASTNode, document: TextDocument, message: string): Diagnostic {
+    const { length, offset } = propNode.keyNode
+    const range = Range.create(document.positionAt(offset), document.positionAt(offset + length))
+
+    return Diagnostic.create(range, message, DiagnosticSeverity.Error)
+}

--- a/src/validation/utils/validatePropertiesUtils.ts
+++ b/src/validation/utils/validatePropertiesUtils.ts
@@ -1,0 +1,144 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+    ArrayASTNode,
+    ASTNode,
+    Diagnostic,
+    DiagnosticSeverity,
+    ObjectASTNode,
+    PropertyASTNode,
+    Range,
+    TextDocument,
+} from 'vscode-json-languageservice';
+
+import {
+    isObjectNode,
+} from '../../utils/astUtilityFunctions'
+
+import { MESSAGES } from '../../constants/diagnosticStrings'
+import schema from '../validationSchema'
+
+const referenceTypes = schema.ReferenceTypes
+
+export interface SchemaObject { [property: string]: SchemaObject | boolean | string }
+
+export interface DiagnosticsForNodeFunc {
+    (
+        rootNode: ASTNode,
+        document: TextDocument,
+        schemaPart: SchemaObject,
+    ): Diagnostic[]
+}
+
+export function isObject(obj: any): obj is Object {
+    return obj === Object(obj);
+}
+
+export function getPropertyNodeDiagnostic(propNode: PropertyASTNode, document: TextDocument, message: string): Diagnostic {
+    const { length, offset } = propNode.keyNode
+    const range = Range.create(document.positionAt(offset), document.positionAt(offset + length))
+
+    return Diagnostic.create(range, message, DiagnosticSeverity.Error)
+}
+
+export function getDiagnosticsForArrayOfSchema(
+    rootNode: ArrayASTNode,
+    document: TextDocument,
+    arraySchema: string,
+    getDiagnosticsForNode: DiagnosticsForNodeFunc
+) {
+    const newSchemaPart = referenceTypes[arraySchema] as SchemaObject
+    let diagnostics: Diagnostic[] = []
+
+    if (isObject(newSchemaPart)) {
+        rootNode.items.forEach(itemNode => {
+            if (isObjectNode(itemNode)) {
+                diagnostics = diagnostics.concat(
+                    getDiagnosticsForNode(itemNode, document, newSchemaPart)
+                )
+            }
+        })
+    }
+
+    return diagnostics
+}
+
+export function getDiagnosticsForOneOfSchema(
+    rootNode: ObjectASTNode,
+    document: TextDocument,
+    schemaPart: SchemaObject,
+    oneOfSchema: string,
+    getDiagnosticsForNode: DiagnosticsForNodeFunc
+) {
+    const mutuallyExclusiveProperties: unknown = referenceTypes[oneOfSchema]
+    const mutuallyExclusivePropertiesPresent: { propNode: PropertyASTNode, schemaValue: unknown }[] = []
+    let diagnostics: Diagnostic[] = []
+
+    rootNode.properties.forEach(prop => {
+        const propName = prop.keyNode.value
+        const propertySchema = mutuallyExclusiveProperties[propName]
+
+        // If the property is one of mutually exclusive properties
+        if (propertySchema) {
+            mutuallyExclusivePropertiesPresent.push({ propNode: prop, schemaValue: propertySchema})
+        // If the property is neither in the set nor in the schema props
+        } else if (!schemaPart[propName]) {
+            diagnostics.push(
+                getPropertyNodeDiagnostic(prop, document, MESSAGES.INVALID_PROPERTY_NAME)
+            )
+        }
+    })
+
+    // if there is more than one item mark them all as invalid
+    if (mutuallyExclusivePropertiesPresent.length > 1) {
+        mutuallyExclusivePropertiesPresent.forEach(oneOfProp => {
+            diagnostics.push(
+                getPropertyNodeDiagnostic(oneOfProp.propNode, document, MESSAGES.MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES)
+            )
+        })
+    // if there is only one item and it is an object
+    // recursively continue on with validation
+    } else if (mutuallyExclusivePropertiesPresent.length) {
+        const { schemaValue, propNode } = mutuallyExclusivePropertiesPresent[0]
+        const { valueNode } = propNode
+        if (isObject(schemaValue)) {
+            diagnostics = diagnostics.concat(
+                getDiagnosticsForNode(valueNode, document, schemaValue as SchemaObject)
+            )
+        }
+    }
+
+    return diagnostics
+}
+
+export function getDiagnosticsForRegularProperties(
+    rootNode: ObjectASTNode,
+    document: TextDocument,
+    schemaPart: SchemaObject,
+    getDiagnosticsForNode: DiagnosticsForNodeFunc
+) {
+    const diagnostics: Diagnostic[] = []
+
+    if (schemaPart.properties) {
+        schemaPart = schemaPart.properties as SchemaObject
+    }
+
+    rootNode.properties.forEach(prop => {
+        const propName = prop.keyNode.value
+        const propertySchema: unknown = schemaPart[propName]
+
+        if (!propertySchema) {
+            diagnostics.push(
+                getPropertyNodeDiagnostic(prop, document, MESSAGES.INVALID_PROPERTY_NAME)
+            )
+        } else if (isObject(propertySchema)) {
+            // evaluate nested schema
+            diagnostics.push(...getDiagnosticsForNode(prop.valueNode, document, propertySchema as SchemaObject))
+        }
+    })
+
+    return diagnostics
+}

--- a/src/validation/validateProperties.ts
+++ b/src/validation/validateProperties.ts
@@ -11,55 +11,17 @@ import {
 
 import {
     findPropChildByName,
-    isArrayNode,
-    isObjectNode,
 } from '../utils/astUtilityFunctions'
 
-import {
-    DiagnosticsForNodeFunc,
-    getDiagnosticsForArrayOfSchema,
-    getDiagnosticsForOneOfSchema,
-    getDiagnosticsForRegularProperties,
-    SchemaObject,
-} from './utils/validatePropertiesUtils'
+import getDiagnosticsForNode from './utils/getDiagnosticsForNode'
 
 import schema from './validationSchema'
-
-const referenceTypes = schema.ReferenceTypes
-
-const getDiagnosticsForNode: DiagnosticsForNodeFunc = function(rootNode, document, schemaPart) {
-    const arrayOfType = schemaPart['Fn:ArrayOf']
-    const oneOfType = schemaPart['Fn:OneOf']
-    const valueOfType = schemaPart['Fn:ValueOf']
-
-    // Fn:ArrayOf
-    // if it contains Fn:ArrayOf property all the other values will be ignored
-    if (typeof arrayOfType === 'string' && isArrayNode(rootNode)) {
-        return getDiagnosticsForArrayOfSchema(rootNode, document, arrayOfType, getDiagnosticsForNode)
-
-    // Fn:OneOf
-    } else if (typeof oneOfType === 'string' && isObjectNode(rootNode)) {
-        return getDiagnosticsForOneOfSchema(rootNode, document, schemaPart, oneOfType, getDiagnosticsForNode)
-    // Fn:ValueOf
-    } else if (typeof valueOfType === 'string' && isObjectNode(rootNode)) {
-        const newSchemaPart = referenceTypes[valueOfType] as SchemaObject
-
-        return getDiagnosticsForNode(rootNode, document, newSchemaPart)
-    // Regular properties
-    } else if (isObjectNode(rootNode)) {
-        return getDiagnosticsForRegularProperties(rootNode, document, schemaPart, getDiagnosticsForNode)
-    }
-
-    return []
-}
 
 export default function(oneStateValueNode: ObjectASTNode, document: TextDocument): Diagnostic[] {
     // Get the type of state
     const stateType = findPropChildByName(oneStateValueNode, 'Type')?.valueNode?.value
     const diagnostics: Diagnostic[] = []
 
-    // By default hasCommonProperties should be true
-    // Only validate common Properties when hasCommonProperties is not false
     if (typeof stateType === 'string') {
         // tslint:disable-next-line no-unsafe-any
         const hasCommonProperties = !!schema.StateTypes[stateType]?.hasCommonProperties

--- a/src/validation/validateProperties.ts
+++ b/src/validation/validateProperties.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+    ArrayASTNode,
+    ASTNode,
+    Diagnostic,
+    DiagnosticSeverity,
+    ObjectASTNode,
+    PropertyASTNode,
+    Range,
+    TextDocument,
+} from 'vscode-json-languageservice';
+
+import {
+    findPropChildByName,
+    isArrayNode,
+    isObjectNode,
+} from '../utils/astUtilityFunctions'
+
+import { MESSAGES } from '../constants/diagnosticStrings'
+
+import schema from './validationSchema'
+
+function isObject(obj: any): obj is Object {
+    return obj === Object(obj);
+  }
+
+function propertyAnalizer(
+    rootNode: ASTNode,
+    document: TextDocument,
+    schemaPart: Object,
+    schemaSets: Object
+): Diagnostic[] {
+    let diagnostics: Diagnostic[] = []
+
+    const arraySchema = schemaPart['Fn:ArrayOf']
+    const oneOfSchema = schemaPart['Fn:OneOf']
+    const valueOfSchema = schemaPart['Fn:ValueOf']
+
+    // Fn:ArrayOf
+    // if it contains Fn:ArrayOf property all the other values will be ignored
+    if (typeof arraySchema === 'string' && isArrayNode(rootNode)) {
+        const newSchemaPart: unknown = schemaSets[arraySchema]
+
+        if (isObject(newSchemaPart)) {
+            rootNode.items.forEach(itemNode => {
+                if (isObjectNode(itemNode)) {
+                    diagnostics = diagnostics.concat(propertyAnalizer(itemNode, document, newSchemaPart, schemaSets))
+                }
+            })
+        }
+
+        return diagnostics
+
+    // Fn:OneOf
+    // TODO: Allow for both OneOf and ValueOf at the same time
+    } else if (typeof oneOfSchema === 'string' && isObjectNode(rootNode)) {
+        const oneOfSet: unknown = schemaSets[oneOfSchema]
+        const itemsOfOneOfSet: { propNode: PropertyASTNode, schemaValue: unknown }[] = []
+
+        rootNode.properties.forEach(prop => {
+            const propName = prop.keyNode.value
+            const inOneOfSet = oneOfSet[propName]
+
+            // If the property is in set referenced by Fn:OneOfSet
+            if (inOneOfSet) {
+                itemsOfOneOfSet.push({ propNode: prop, schemaValue: inOneOfSet})
+            // If the property is neither in the set nor in the schema props
+            } else if (!schemaPart[propName]) {
+                diagnostics.push(
+                    getPropertyNodeDiagnostic(prop, document, MESSAGES.INVALID_PROPERTY_NAME)
+                )
+            }
+        })
+
+        // if there is more than one item mark them all as invalid
+        if (itemsOfOneOfSet.length > 1) {
+            const messageSuffix = itemsOfOneOfSet
+                .map(item => item.propNode.keyNode.value)
+                .join(', ')
+
+            itemsOfOneOfSet.forEach(oneOfProp => {
+                diagnostics.push(
+                    getPropertyNodeDiagnostic(oneOfProp.propNode, document, MESSAGES.MUTUALLY_EXCLUSIVE_PROPERTIES + messageSuffix)
+                )
+            })
+        // if there is only one item and it is an object
+        // recursively continue on with validation
+        } else if (itemsOfOneOfSet.length) {
+            const { schemaValue, propNode } = itemsOfOneOfSet[0]
+            const { valueNode } = propNode
+            if (isObject(schemaValue)) {
+                diagnostics = diagnostics.concat(
+                    propertyAnalizer(valueNode, document, schemaValue, schemaSets)
+                )
+            }
+        }
+    // Fn:ValueOf
+    } else if (typeof valueOfSchema === 'string' && isObjectNode(rootNode)) {
+        const newSchemaPart: unknown = schemaSets[valueOfSchema]
+        diagnostics = diagnostics.concat(propertyAnalizer(rootNode, document, newSchemaPart, schemaSets))
+    // Regural properties
+    } else if (isObjectNode(rootNode)) {
+        rootNode.properties.forEach(prop => {
+            const propName = prop.keyNode.value
+
+            if (!schemaPart[propName]) {
+                diagnostics.push(
+                    getPropertyNodeDiagnostic(prop, document, MESSAGES.INVALID_PROPERTY_NAME)
+                )
+            }
+        })
+    }
+
+    return diagnostics
+}
+
+function getPropertyNodeDiagnostic(propNode: PropertyASTNode, document: TextDocument, message: string): Diagnostic {
+        const { length, offset } = propNode.keyNode
+        const range = Range.create(document.positionAt(offset), document.positionAt(offset + length))
+
+        return Diagnostic.create(range, message, DiagnosticSeverity.Error)
+}
+
+export default function(oneStateValueNode: ObjectASTNode, document: TextDocument): Diagnostic[] {
+    // Get the type of state
+    const typeNode = findPropChildByName(oneStateValueNode, 'Type')
+    const typeName = typeNode?.valueNode.value
+
+    let diagnostics: Diagnostic[] = []
+
+    oneStateValueNode.properties.forEach(prop => {
+        const propName = prop.keyNode.value
+        let hasCommonFields = true
+
+        // By default hasCommonFields should be true
+        // Only validate common fields when hasCommonFields is not false
+        if (typeof typeName === 'string') {
+            // tslint:disable-next-line no-unsafe-any
+            hasCommonFields = schema.Specific[typeName]?.hasCommonFields !== false
+        }
+
+        const isPropertyWithinCommon = hasCommonFields && !!schema.Common[propName]
+
+        if (isPropertyWithinCommon) {
+            return
+        }
+
+        if (!isPropertyWithinCommon && typeof typeName === 'string') {
+            // tslint:disable-next-line no-unsafe-any
+            const propertySchemaWithinSpecific: unknown = schema.Specific[typeName]?.Properties?.[propName]
+
+            if (propertySchemaWithinSpecific) {
+                if (isObject(propertySchemaWithinSpecific)) {
+                    diagnostics = diagnostics.concat(
+                        propertyAnalizer(prop.valueNode, document, propertySchemaWithinSpecific, schema.Sets)
+                    )
+                }
+
+                return
+            }
+        }
+
+        const diagnostic = getPropertyNodeDiagnostic(prop, document, MESSAGES.INVALID_PROPERTY_NAME)
+
+        diagnostics.push(diagnostic)
+    })
+
+    return diagnostics
+}

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -12,7 +12,7 @@ import {
     PropertyASTNode,
     Range,
     TextDocument,
-} from 'vscode-json-languageservice';
+} from 'vscode-json-languageservice'
 
 import {
     findPropChildByName,
@@ -22,7 +22,7 @@ import {
 } from '../utils/astUtilityFunctions'
 
 import { MESSAGES } from '../constants/diagnosticStrings'
-import { getPropertyNodeDiagnostic } from './utils/validatePropertiesUtils'
+import getPropertyNodeDiagnostic from './utils/getPropertyNodeDiagnostic'
 import validateProperties from './validateProperties'
 import schema from './validationSchema'
 

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -22,7 +22,8 @@ import {
 } from '../utils/astUtilityFunctions'
 
 import { MESSAGES } from '../constants/diagnosticStrings'
-import validateProperties, { getPropertyNodeDiagnostic } from './validateProperties'
+import { getPropertyNodeDiagnostic } from './utils/validatePropertiesUtils'
+import validateProperties from './validateProperties'
 import schema from './validationSchema'
 
 function stateNameExistsInPropNode(

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -21,13 +21,8 @@ import {
     isObjectNode,
 } from '../utils/astUtilityFunctions'
 
-export const MESSAGES = {
-    INVALID_NEXT: 'The value of "Next" property must be the name of an existing state.',
-    INVALID_DEFAULT: 'The value of "Default" property must be the name of an existing state.',
-    INVALID_START_AT: 'The value of "StartAt" property must be the name of an existing state.',
-    UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
-    NO_TERMINAL_STATE: 'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).'
-}
+import { MESSAGES } from '../constants/diagnosticStrings'
+import validateProperties from './validateProperties'
 
 function stateNameExistsInPropNode(
     nextPropNode: PropertyASTNode,
@@ -113,6 +108,8 @@ export default function validateStates(rootNode: ObjectASTNode, document: TextDo
                 const oneStateValueNode = prop.valueNode
 
                 if (oneStateValueNode && isObjectNode(oneStateValueNode)) {
+                    diagnostics = diagnostics.concat(validateProperties(oneStateValueNode, document))
+
                     const nextPropNode = findPropChildByName(oneStateValueNode, 'Next')
                     const endPropNode = findPropChildByName(oneStateValueNode, 'End')
 

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -112,7 +112,7 @@ export default {
             },
             BooleanEquals: true,
             Not: {
-                'Fn:ValueOf': 'ChoiceRule'
+                'Fn:ValueOf': 'NestedChoiceRule'
             },
             NumericEquals: true,
             NumericGreaterThan: true,

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -1,0 +1,152 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+export default {
+    Common: {
+        Next: true,
+        End: true,
+        Comment: true,
+        InputPath: true,
+        OutputPath: true,
+        Type: true
+    },
+    Specific: {
+        Pass: {
+            Properties: {
+                Result: true,
+                ResultPath: true,
+                Parameters: true
+            }
+        },
+        Task: {
+            Properties: {
+                Resource: true,
+                Parameters: true,
+                ResultPath: true,
+                TimeoutSeconds: true,
+                HeartbeatSeconds: true,
+                Retry: {
+                    'Fn:ArrayOf': 'Retry'
+                },
+                Catch: {
+                    'Fn:ArrayOf': 'Catch'
+                }
+            }
+        },
+        Choice: {
+            Properties: {
+                Choices: {
+                    'Fn:ArrayOf': 'Choices'
+                },
+                Default: true
+            }
+        },
+        Wait: {
+            Properties: {
+                Seconds: true,
+                Timestamp: true,
+                SecondsPath: true,
+                TimestampPath: true
+            }
+        },
+        Succeed: {
+            Properties: {
+                Type: true
+            },
+            hasCommonFields: false
+        },
+        Fail: {
+            Properties: {
+                Cause: true,
+                Error: true,
+                Comment: true,
+                Type:  true
+            },
+            hasCommonFields: false
+        },
+        Parallel: {
+            Properties: {
+                Branches: true,
+                ResultPath: true,
+                Retry: {
+                    'Fn:ArrayOf': 'Retry'
+                },
+                Catch: {
+                    'Fn:ArrayOf': 'Catch'
+                }
+            }
+        },
+        Map: {
+            Properties: {
+                Iterator: true,
+                ItemsPath: true,
+                MaxConcurrency: true,
+                ResultPath: true,
+                Retry: {
+                    'Fn:ArrayOf': 'Retry'
+                },
+                Catch: {
+                    'Fn:ArrayOf': 'Catch'
+                }
+            }
+        }
+    },
+    Sets: {
+        ChoiceRules: {
+            And: {
+                'Fn:ArrayOf': 'Choices'
+            },
+            BooleanEquals: true,
+            Not: {
+                'Fn:ValueOf': 'Choices'
+            },
+            NumericEquals: true,
+            NumericGreaterThan: true,
+            NumericGreaterThanEquals: true,
+            NumericLessThan: true,
+            NumericLessThanEquals: true,
+            Or: {
+                'Fn:ArrayOf': 'Choices'
+            },
+            StringEquals: true,
+            StringGreaterThan: true,
+            StringGreaterThanEquals: true,
+            StringLessThan: true,
+            StringLessThanEquals: true,
+            TimestampEquals: true,
+            TimestampGreaterThan: true,
+            TimestampGreaterThanEquals: true,
+            TimestampLessThan: true,
+            TimestampLessThanEquals: true
+        },
+
+        Choices: {
+            'Fn:OneOf': 'ChoiceRules',
+            Variable: true,
+            Next: true
+        },
+
+        Catch: {
+            ErrorEquals: true,
+            ResultPath: true,
+            Next: true
+        },
+
+        Retry: {
+            ErrorEquals: true,
+            IntervalSeconds: true,
+            MaxAttempts: true,
+            BackoffRate: true
+        }
+    },
+    Root: {
+        Comment: true,
+        StartAt: true,
+        TimeoutSeconds: true,
+        Version: true,
+        States: true
+    }
+
+}

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -37,10 +37,15 @@ export default {
         },
         Choice: {
             Properties: {
+                Comment: true,
+                InputPath: true,
+                OutputPath: true,
+                Type: true,
                 Choices: {
                     'Fn:ArrayOf': 'Choices'
                 },
-                Default: true
+                Default: true,
+                hasCommonFields: false
             }
         },
         Wait: {
@@ -53,7 +58,10 @@ export default {
         },
         Succeed: {
             Properties: {
-                Type: true
+                Type: true,
+                Comment: true,
+                InputPath: true,
+                OutputPath: true,
             },
             hasCommonFields: false
         },
@@ -70,6 +78,7 @@ export default {
             Properties: {
                 Branches: true,
                 ResultPath: true,
+                Parameters: true,
                 Retry: {
                     'Fn:ArrayOf': 'Retry'
                 },
@@ -84,6 +93,7 @@ export default {
                 ItemsPath: true,
                 MaxConcurrency: true,
                 ResultPath: true,
+                Parameters: true,
                 Retry: {
                     'Fn:ArrayOf': 'Retry'
                 },
@@ -121,19 +131,16 @@ export default {
             TimestampLessThan: true,
             TimestampLessThanEquals: true
         },
-
         Choices: {
             'Fn:OneOf': 'ChoiceRules',
             Variable: true,
             Next: true
         },
-
         Catch: {
             ErrorEquals: true,
             ResultPath: true,
             Next: true
         },
-
         Retry: {
             ErrorEquals: true,
             IntervalSeconds: true,
@@ -147,6 +154,11 @@ export default {
         TimeoutSeconds: true,
         Version: true,
         States: true
+    },
+    // State machines nested within Map and Parallel states
+    NestedRoot: {
+        Comment: true,
+        StartAt: true,
+        States: true
     }
-
 }

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -12,13 +12,14 @@ export default {
         OutputPath: true,
         Type: true
     },
-    Specific: {
+    StateTypes: {
         Pass: {
             Properties: {
                 Result: true,
                 ResultPath: true,
                 Parameters: true
-            }
+            },
+            hasCommonProperties: true
         },
         Task: {
             Properties: {
@@ -28,12 +29,13 @@ export default {
                 TimeoutSeconds: true,
                 HeartbeatSeconds: true,
                 Retry: {
-                    'Fn:ArrayOf': 'Retry'
+                    'Fn:ArrayOf': 'Retrier'
                 },
                 Catch: {
-                    'Fn:ArrayOf': 'Catch'
+                    'Fn:ArrayOf': 'Catcher'
                 }
-            }
+            },
+            hasCommonProperties: true
         },
         Choice: {
             Properties: {
@@ -42,10 +44,9 @@ export default {
                 OutputPath: true,
                 Type: true,
                 Choices: {
-                    'Fn:ArrayOf': 'Choices'
+                    'Fn:ArrayOf': 'ChoiceRule'
                 },
                 Default: true,
-                hasCommonFields: false
             }
         },
         Wait: {
@@ -54,7 +55,8 @@ export default {
                 Timestamp: true,
                 SecondsPath: true,
                 TimestampPath: true
-            }
+            },
+            hasCommonProperties: true
         },
         Succeed: {
             Properties: {
@@ -62,8 +64,7 @@ export default {
                 Comment: true,
                 InputPath: true,
                 OutputPath: true,
-            },
-            hasCommonFields: false
+            }
         },
         Fail: {
             Properties: {
@@ -71,8 +72,7 @@ export default {
                 Error: true,
                 Comment: true,
                 Type:  true
-            },
-            hasCommonFields: false
+            }
         },
         Parallel: {
             Properties: {
@@ -80,12 +80,13 @@ export default {
                 ResultPath: true,
                 Parameters: true,
                 Retry: {
-                    'Fn:ArrayOf': 'Retry'
+                    'Fn:ArrayOf': 'Retrier'
                 },
                 Catch: {
-                    'Fn:ArrayOf': 'Catch'
+                    'Fn:ArrayOf': 'Catcher'
                 }
-            }
+            },
+            hasCommonProperties: true
         },
         Map: {
             Properties: {
@@ -95,22 +96,23 @@ export default {
                 ResultPath: true,
                 Parameters: true,
                 Retry: {
-                    'Fn:ArrayOf': 'Retry'
+                    'Fn:ArrayOf': 'Retrier'
                 },
                 Catch: {
-                    'Fn:ArrayOf': 'Catch'
+                    'Fn:ArrayOf': 'Catcher'
                 }
-            }
+            },
+            hasCommonProperties: true
         }
     },
-    Sets: {
-        ChoiceRules: {
+    ReferenceTypes: {
+        ComparisonOperators: {
             And: {
-                'Fn:ArrayOf': 'Choices'
+                'Fn:ArrayOf': 'NestedChoiceRule'
             },
             BooleanEquals: true,
             Not: {
-                'Fn:ValueOf': 'Choices'
+                'Fn:ValueOf': 'ChoiceRule'
             },
             NumericEquals: true,
             NumericGreaterThan: true,
@@ -118,7 +120,7 @@ export default {
             NumericLessThan: true,
             NumericLessThanEquals: true,
             Or: {
-                'Fn:ArrayOf': 'Choices'
+                'Fn:ArrayOf': 'NestedChoiceRule'
             },
             StringEquals: true,
             StringGreaterThan: true,
@@ -131,17 +133,21 @@ export default {
             TimestampLessThan: true,
             TimestampLessThanEquals: true
         },
-        Choices: {
-            'Fn:OneOf': 'ChoiceRules',
+        ChoiceRule: {
+            'Fn:OneOf': 'ComparisonOperators',
             Variable: true,
             Next: true
         },
-        Catch: {
+        NestedChoiceRule: {
+            'Fn:OneOf': 'ComparisonOperators',
+             Variable: true,
+        },
+        Catcher: {
             ErrorEquals: true,
             ResultPath: true,
             Next: true
         },
-        Retry: {
+        Retrier: {
             ErrorEquals: true,
             IntervalSeconds: true,
             MaxAttempts: true,


### PR DESCRIPTION
*Description of changes:*
I added functionality to detect invalid properties within ASL schema. It can't be accomplished with JSONSchema. I implemented a simple schema myself that will allow for configuration of which properties are allowed and which are not: `src/validation/validationSchema.ts`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
