### PR TITLE
Removes ItemsPath from required props of Map state

### DIFF
--- a/src/json-schema/bundled.json
+++ b/src/json-schema/bundled.json
@@ -1335,7 +1335,6 @@
 									}
 								},
 								"required": [
-									"ItemsPath",
 									"Iterator"
 								]
 							}

--- a/src/json-schema/partial/map_state.json
+++ b/src/json-schema/partial/map_state.json
@@ -60,7 +60,6 @@
                         }
                     },
                     "required": [
-                        "ItemsPath",
                         "Iterator"
                     ]
                 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-toolkit-vscode/issues/1196

*Description of changes:*
I removed ItemsPath from list of required properties of Map state. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
