### PR TITLE
Feature/export schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,7 +27,8 @@ export * from 'vscode-json-languageservice'
 
 interface ASLLanguageServiceParams extends LanguageServiceParams { aslOptions?: ASLOptions }
 
-export const ASLSCHEMA = aslSchema as JSONSchema
+export const ASL_SCHEMA = aslSchema as JSONSchema
+export const doCompleteAsl = completeAsl
 
 export const getLanguageService = function( params: ASLLanguageServiceParams): LanguageService {
     const builtInParams = {}

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,6 +27,8 @@ export * from 'vscode-json-languageservice'
 
 interface ASLLanguageServiceParams extends LanguageServiceParams { aslOptions?: ASLOptions }
 
+export const ASLSCHEMA = aslSchema as JSONSchema
+
 export const getLanguageService = function( params: ASLLanguageServiceParams): LanguageService {
     const builtInParams = {}
 


### PR DESCRIPTION
Creates an export for the ASL Schema so it can be imported from amazon-states-language-service.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
