### PR TITLE
Fix bug marking states as unreachable when defined before a Choice state

### DIFF
--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -877,6 +877,25 @@ export const documentChoiceDefaultBeforeChoice = `{
   }
 }`
 
+export const documentChoiceNextBeforeChoice = `{
+  "StartAt": "ChoiceState",
+  "States": {
+    "FailState": {
+      "Type": "Fail"
+    },
+    "ChoiceState": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.myVariable",
+          "StringEquals": "bug",
+          "Next": "FailState"
+        }
+      ]
+    }
+  }
+}`
+
 export const documentInvalidPropertiesState = `{
   "StartAt": "FirstState",
   "States": {

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -12,6 +12,7 @@ import {
     documentChoiceDefaultBeforeChoice,
     documentChoiceInvalidDefault,
     documentChoiceInvalidNext,
+    documentChoiceNextBeforeChoice,
     documentChoiceNoDefault,
     documentChoiceValidDefault,
     documentChoiceValidNext,
@@ -248,6 +249,13 @@ suite('ASL context-aware validation', () => {
                     },
                 ],
                 filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE]
+            })
+        })
+
+        test('Doesn\'t show Diagnostic for valid state name when Next state is declared before Choice state', async () => {
+            await testValidations({
+                json: documentChoiceNextBeforeChoice,
+                diagnostics: []
             })
         })
     })


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws/amazon-states-language-service/issues/53
* aws/aws-toolkit-vscode#1117 (comment)

### Description of changes:
Validation for state reachability was dependent on the order that they were defined in the document. A state declared before the Choice Rule referencing it was marked as an invalid state.

To simply state tracking, I am removing the map of unreachable states in favour of using just the reachedStates map.


### Testing done 
* Added a unit test covering this case and all existing tests are passing
* Manually tested change in aws-toolkit-code with the definition provided in https://github.com/aws/amazon-states-language-service/issues/53


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
