### PR TITLE
Moving ASL YAML functionality to ASL service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -44,6 +44,19 @@
 			"integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
 			"dev": true
 		},
+		"@types/prettier": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
+			"integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ=="
+		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
 		"ansi-colors": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -79,7 +92,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -247,7 +259,6 @@
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -319,6 +330,19 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -328,8 +352,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esutils": {
 			"version": "1.1.6",
@@ -445,6 +468,39 @@
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"requires": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			}
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -555,7 +611,6 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -678,8 +733,7 @@
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-			"dev": true
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"node-environment-flags": {
 			"version": "1.0.6",
@@ -794,6 +848,11 @@
 			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
 			"dev": true
 		},
+		"prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+		},
 		"readdirp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -801,6 +860,16 @@
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.0.4"
+			}
+		},
+		"request-light": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.5.tgz",
+			"integrity": "sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==",
+			"requires": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.3",
+				"vscode-nls": "^4.1.1"
 			}
 		},
 		"require-directory": {
@@ -839,8 +908,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -1115,6 +1183,112 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
+		},
+		"yaml-ast-parser-custom-tags": {
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz",
+			"integrity": "sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ=="
+		},
+		"yaml-language-server": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-0.10.0.tgz",
+			"integrity": "sha512-d2/7eGgonEIRcnW9kK+k+ERG4gTOk5BXHr9KjTVv8gEarXKa62Kk+nyFE4AXgMDZ0LXTu8nTuN/AdboJiGN+pQ==",
+			"requires": {
+				"js-yaml": "^3.13.1",
+				"jsonc-parser": "^2.2.1",
+				"prettier": "2.0.5",
+				"request-light": "^0.2.4",
+				"vscode-json-languageservice": "^3.6.0",
+				"vscode-languageserver": "^5.2.1",
+				"vscode-languageserver-types": "^3.15.1",
+				"vscode-nls": "^4.1.2",
+				"vscode-uri": "^2.1.1",
+				"yaml-ast-parser-custom-tags": "0.0.43"
+			},
+			"dependencies": {
+				"prettier": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+					"integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+					"optional": true
+				},
+				"vscode-json-languageservice": {
+					"version": "3.8.4",
+					"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.8.4.tgz",
+					"integrity": "sha512-njDG0+YJvYNKXH+6plQGZMxgbifATFrRpC6Qnm/SAn4IW8bMHxsYunsxrjtpqK42CVSz6Lr7bpbTEZbVuOmFLw==",
+					"requires": {
+						"jsonc-parser": "^2.3.1",
+						"vscode-languageserver-textdocument": "^1.0.1",
+						"vscode-languageserver-types": "3.16.0-next.2",
+						"vscode-nls": "^5.0.0",
+						"vscode-uri": "^2.1.2"
+					},
+					"dependencies": {
+						"jsonc-parser": {
+							"version": "2.3.1",
+							"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+							"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+						},
+						"vscode-languageserver-types": {
+							"version": "3.16.0-next.2",
+							"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+							"integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
+						},
+						"vscode-nls": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+							"integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
+						},
+						"vscode-uri": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
+							"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
+						}
+					}
+				},
+				"vscode-jsonrpc": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+					"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+				},
+				"vscode-languageserver": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
+					"integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
+					"requires": {
+						"vscode-languageserver-protocol": "3.14.1",
+						"vscode-uri": "^1.0.6"
+					},
+					"dependencies": {
+						"vscode-uri": {
+							"version": "1.0.8",
+							"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
+							"integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
+						}
+					}
+				},
+				"vscode-languageserver-protocol": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+					"integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+					"requires": {
+						"vscode-jsonrpc": "^4.0.0",
+						"vscode-languageserver-types": "3.14.0"
+					},
+					"dependencies": {
+						"vscode-languageserver-types": {
+							"version": "3.14.0",
+							"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+							"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+						}
+					}
+				},
+				"vscode-nls": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+					"integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+				}
+			}
 		},
 		"yargs": {
 			"version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,21 @@
 		"typescript": "^3.7.5"
 	},
 	"dependencies": {
-		"@types/prettier": "^2.1.1",
 		"prettier": "^1.19.1",
 		"vscode-json-languageservice": "3.4.9",
 		"vscode-languageserver": "^6.1.1",
 		"vscode-languageserver-textdocument": "^1.0.0",
 		"vscode-languageserver-types": "^3.15.1",
 		"yaml-language-server": "0.10.0"
-	}
+	},
+    "prettier": {
+        "printWidth": 120,
+        "trailingComma": "es5",
+        "tabWidth": 4,
+        "singleQuote": true,
+        "semi": false,
+        "bracketSpacing": true,
+        "arrowParens": "avoid",
+        "endOfLine": "lf"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"typescript": "^3.7.5"
 	},
 	"dependencies": {
+		"@types/prettier": "^2.1.1",
 		"prettier": "^1.19.1",
 		"vscode-json-languageservice": "3.4.9",
 		"vscode-languageserver": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"
@@ -36,8 +36,12 @@
 		"typescript": "^3.7.5"
 	},
 	"dependencies": {
+		"@types/prettier": "^2.1.1",
+		"prettier": "^1.19.1",
 		"vscode-json-languageservice": "3.4.9",
 		"vscode-languageserver": "^6.1.1",
-		"vscode-languageserver-textdocument": "^1.0.0"
+		"vscode-languageserver-textdocument": "^1.0.0",
+		"vscode-languageserver-types": "^3.15.1",
+		"yaml-language-server": "0.10.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
 		"vscode-languageserver-types": "^3.15.1",
 		"yaml-language-server": "0.10.0"
 	},
-    "prettier": {
-        "printWidth": 120,
-        "trailingComma": "es5",
-        "tabWidth": 4,
-        "singleQuote": true,
-        "semi": false,
-        "bracketSpacing": true,
-        "arrowParens": "avoid",
-        "endOfLine": "lf"
-    }
+	"prettier": {
+		"printWidth": 120,
+		"trailingComma": "es5",
+		"tabWidth": 4,
+		"singleQuote": true,
+		"semi": false,
+		"bracketSpacing": true,
+		"arrowParens": "avoid",
+		"endOfLine": "lf"
+	}
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,6 +22,7 @@ import {
 
 import completeAsl from './completion/completeAsl'
 import validateStates from './validation/validateStates'
+import { getLanguageService as getAslYamlLanguageService } from './yaml/aslYamlLanguageService'
 
 export * from 'vscode-json-languageservice'
 
@@ -79,4 +80,17 @@ export const getLanguageService = function( params: ASLLanguageServiceParams): L
     }
 
     return languageService
+}
+
+export const getYamlLanguageService = function( params: ASLLanguageServiceParams): LanguageService {
+    const aslLanguageService: LanguageService = getLanguageService({
+        workspaceContext: params.workspaceContext,
+        contributions: params.contributions,
+        clientCapabilities: params.clientCapabilities,
+        aslOptions: {
+            ignoreColonOffset: true,
+        },
+    })
+
+    return getAslYamlLanguageService(params, ASL_SCHEMA, aslLanguageService);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -84,9 +84,7 @@ export const getLanguageService = function( params: ASLLanguageServiceParams): L
 
 export const getYamlLanguageService = function( params: ASLLanguageServiceParams): LanguageService {
     const aslLanguageService: LanguageService = getLanguageService({
-        workspaceContext: params.workspaceContext,
-        contributions: params.contributions,
-        clientCapabilities: params.clientCapabilities,
+        ...params,
         aslOptions: {
             ignoreColonOffset: true,
         },

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -243,7 +243,6 @@ suite('ASL YAML context-aware completion', () => {
         })
 
         test('Suggests nested completions when Next is nested within Map state', async () => {
-            console.log(nestedItemLabels)
             await testCompletions({
                 // remove last label as it is the name of the current state
                 labels: nestedItemLabels.filter(label => label !== 'Nested4'),

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -1,0 +1,301 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as assert from 'assert'
+import { getYamlLanguageService, Position, Range } from '../service'
+import { toDocument } from './utils/testUtilities'
+
+const document1 = `
+  StartAt:
+  States:
+    FirstState:
+    ChoiceState:
+    FirstMatchState:
+    SecondMatchState:
+    DefaultState:
+    NextState:
+      Next: ""
+    ChoiceStateX:
+      Type: Choice
+      Choices:
+        - Next: ""
+        - Next: FirstState
+        - Next: NextState
+      Default: ""
+`
+const document2 = `
+  StartAt:
+  States:
+    FirstState:
+    ChoiceState:
+    FirstMatchState:
+    SecondMatchState:
+    DefaultState:
+    NextState:
+      Next: ""
+    ChoiceStateX:
+      Type: Choice,
+      Choices:
+        - Next: ""
+        - Next: FirstState
+        - Next: NextState
+      Default: ""
+`
+
+const document3 = `
+  StartAt: ""
+  States:
+    FirstState:
+    ChoiceState:
+    FirstMatchState:
+    SecondMatchState:
+    DefaultState:
+    NextState:
+      Next: ""
+    ChoiceStateX:
+`
+const document4 = `
+  StartAt: First
+  States:
+    FirstState:
+    ChoiceState:
+    FirstMatchState:
+    SecondMatchState:
+    DefaultState:
+    NextState:
+      Next: First
+    ChoiceStateX:
+`
+
+const documentNested = `
+  StartAt: First
+  States:
+    FirstState:
+    MapState:
+      Iterator:
+        StartAt: ""
+        States:
+          Nested1:
+          Nested2:
+          Nested3:
+          Nested4:
+            Next: ""
+`
+const completionsEdgeCase1 = `
+  Comment: An example of the Amazon States Language using a map state to process elements of an array with a max concurrency of 2.
+  StartAt: Map
+  States:
+    Map:
+      Type: Map
+      ItemsPath: $.array
+      ResultPath: \\\$$$$$.array$$$
+      MaxConcurrency: 2
+      Next: Final State
+      Iterator:
+        StartAt: Pass
+        States:
+          Pass:
+            Type: Pass
+            Result: Done!
+            End: true
+    "Net 2":
+      Type: Fail
+      Next: Final State
+    Final State:
+      Type: Pass
+      Next: "Net 2"
+`
+
+const completionsEdgeCase2 = `
+  StartAt: MyState
+  States:
+
+`
+
+const itemLabels = [
+    'FirstState',
+    'ChoiceState',
+    'FirstMatchState',
+    'SecondMatchState',
+    'DefaultState',
+    'NextState',
+    'ChoiceStateX',
+]
+const nestedItemLabels = ['Nested1', 'Nested2', 'Nested3', 'Nested4']
+
+interface TestCompletionOptions {
+    labels: string[]
+    json: string
+    position: [number, number]
+    start: [number, number]
+    end: [number, number]
+    labelToInsertText(label: string): string
+}
+
+async function getCompletions(json: string, position: [number, number]) {
+    const { textDoc, jsonDoc } = toDocument(json)
+    const pos = Position.create(...position)
+    const ls = getYamlLanguageService({})
+
+    return await ls.doComplete(textDoc, pos, jsonDoc)
+}
+
+async function testCompletions(options: TestCompletionOptions) {
+    const { labels, json, position, start, end, labelToInsertText } = options
+
+    const res = await getCompletions(json, position)
+
+    assert.strictEqual(res?.items.length, labels.length)
+
+    // space before quoted item
+    const itemInsertTexts = labels.map(labelToInsertText)
+
+    assert.deepEqual(
+        res?.items.map(item => item.label),
+        labels
+    )
+    assert.deepEqual(
+        res?.items.map(item => item.textEdit?.newText),
+        itemInsertTexts
+    )
+
+    const leftPos = Position.create(...start)
+    const rightPos = Position.create(...end)
+
+    res?.items.forEach(item => {
+        assert.deepEqual(item.textEdit?.range, Range.create(leftPos, rightPos))
+    })
+}
+
+suite('ASL YAML context-aware completion', () => {
+    suite('StartAt', () => {
+        test('Both quotation marks present and cursor between them', async () => {
+            await testCompletions({
+                labels: itemLabels,
+                json: document3,
+                position: [1, 12],
+                start: [1, 12],
+                end: [1, 13],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests completions when text present and cursor is on it', async () => {
+            await testCompletions({
+                labels: itemLabels,
+                json: document4,
+                position: [1, 13],
+                start: [1, 12],
+                end: [1, 16],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests nested completions when StartAt is nested within Map state', async () => {
+            await testCompletions({
+                labels: nestedItemLabels,
+                json: documentNested,
+                position: [6, 18],
+                start: [6, 18],
+                end: [6, 19],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+    })
+
+    suite('Next', () => {
+        test('Cursor after colon but no quotes', async () => {
+            await testCompletions({
+                // remove last label as it is the name of the current state
+                labels: itemLabels.filter(label => label !== 'NextState'),
+                json: document2,
+                position: [9, 12],
+                start: [9, 12],
+                end: [9, 14],
+                labelToInsertText: label => `"${label}"`,
+            })
+        })
+
+        test('Both quotation marks present and cursor between them', async () => {
+            await testCompletions({
+                // remove last label as it is the name of the current state
+                labels: itemLabels.filter(label => label !== 'NextState'),
+                json: document3,
+                position: [9, 13],
+                start: [9, 13],
+                end: [9, 14],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests completions when text present and cursor is on it', async () => {
+            await testCompletions({
+                // remove last label as it is the name of the current state
+                labels: itemLabels.filter(label => label !== 'NextState'),
+                json: document4,
+                position: [9, 18],
+                start: [9, 16],
+                end: [9, 17],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests nested completions when Next is nested within Map state', async () => {
+            console.log(nestedItemLabels)
+            await testCompletions({
+                // remove last label as it is the name of the current state
+                labels: nestedItemLabels.filter(label => label !== 'Nested4'),
+                json: documentNested,
+                position: [12, 21],
+                start: [12, 19],
+                end: [12, 20],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests completions for the Next property within Choice state', async () => {
+            await testCompletions({
+                labels: itemLabels.filter(label => label !== 'ChoiceStateX'),
+                json: document1,
+                position: [13, 17],
+                start: [13, 17],
+                end: [13, 18],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+    })
+
+    suite('Default', () => {
+        test('Suggests completion items for Default property of the Choice state when cursor positioned after first quote', async () => {
+            await testCompletions({
+                labels: itemLabels.filter(label => label !== 'ChoiceStateX'),
+                json: document1,
+                position: [16, 16],
+                start: [16, 16],
+                end: [16, 17],
+                labelToInsertText: label => `${label}"`,
+            })
+        })
+
+        test('Suggests completion items for Default property of the Choice state when cursor is a space after colon', async () => {
+            await testCompletions({
+                labels: itemLabels.filter(label => label !== 'ChoiceStateX'),
+                json: document2,
+                position: [16, 15],
+                start: [16, 15],
+                end: [16, 17],
+                labelToInsertText: label => `"${label}"`,
+            })
+        })
+    })
+
+    suite('Edge Cases', () => {
+        test('Requested completion in state name position does not throw error', async () => {
+            await assert.doesNotReject(getCompletions(completionsEdgeCase1, [17, 4]), TypeError)
+
+            await assert.doesNotReject(getCompletions(completionsEdgeCase2, [3, 5]), TypeError)
+        })
+    })
+})

--- a/src/tests/yamlValidation.test.ts
+++ b/src/tests/yamlValidation.test.ts
@@ -1,0 +1,741 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as assert from 'assert'
+import { Diagnostic, DiagnosticSeverity, getYamlLanguageService, Position, Range } from '../service'
+
+import {
+    documentChoiceDefaultBeforeChoice,
+    documentChoiceInvalidDefault,
+    documentChoiceInvalidNext,
+    documentChoiceNoDefault,
+    documentChoiceValidDefault,
+    documentChoiceValidNext,
+    documentInvalidNext,
+    documentInvalidNextNested,
+    documentInvalidParametersIntrinsicFunction,
+    documentInvalidParametersJsonPath,
+    documentInvalidPropertiesCatch,
+    documentInvalidPropertiesChoices,
+    documentInvalidPropertiesRoot,
+    documentInvalidPropertiesRootNested,
+    documentInvalidPropertiesState,
+    documentInvalidResultSelectorIntrinsicFunction,
+    documentInvalidResultSelectorJsonPath,
+    documentMapCatchTemplate,
+    documentMapCatchTemplateInvalidNext,
+    documentNestedNoTerminalState,
+    documentNestedUnreachableState,
+    documentNoTerminalState,
+    documentParallelCatchTemplate,
+    documentParallelCatchTemplateInvalidNext,
+    documentStartAtInvalid,
+    documentStartAtNestedInvalid,
+    documentStartAtValid,
+    documentSucceedFailTerminalState,
+    documentTaskCatchTemplate,
+    documentTaskCatchTemplateInvalidNext,
+    documentTaskInvalidArn,
+    documentTaskValidVariableSubstitution,
+    documentUnreachableState,
+    documentValidAslImprovements,
+    documentValidNext,
+    documentValidParametersIntrinsicFunction,
+    documentValidParametersJsonPath,
+    documentValidResultSelectorIntrinsicFunction,
+    documentValidResultSelectorJsonPath,
+} from './yasl-strings/validationStrings'
+
+import { toDocument } from './utils/testUtilities'
+
+const JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG = 'Matches multiple schemas when only one must validate.'
+
+const MESSAGES = {
+    INVALID_NEXT: 'The value of "Next" property must be the name of an existing state.',
+    INVALID_DEFAULT: 'The value of "Default" property must be the name of an existing state.',
+    INVALID_START_AT: 'The value of "StartAt" property must be the name of an existing state.',
+    INVALID_JSON_PATH_OR_INTRINSIC:
+        'The value for the field must be a valid JSONPath or intrinsic function expression.',
+    UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
+    NO_TERMINAL_STATE:
+        'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
+    INVALID_PROPERTY_NAME: 'Field is not supported.',
+    MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.',
+} as const
+
+export interface TestValidationOptions {
+    json: string
+    diagnostics: {
+        message: string
+        start: [number, number]
+        end: [number, number]
+    }[]
+    filterMessages?: string[]
+}
+
+async function getValidations(json: string) {
+    const { textDoc, jsonDoc } = toDocument(json)
+    const ls = getYamlLanguageService({})
+
+    return await ls.doValidation(textDoc, jsonDoc)
+}
+
+async function testValidations(options: TestValidationOptions) {
+    const { json, diagnostics, filterMessages } = options
+
+    let res = await getValidations(json)
+    console.log(res)
+    res = res.filter(diagnostic => {
+        if (filterMessages && filterMessages.find(message => message === diagnostic.message)) {
+            return false
+        }
+
+        return true
+    })
+
+    assert.strictEqual(res.length, diagnostics.length)
+
+    res.forEach((item, index) => {
+        const leftPos = Position.create(...diagnostics[index].start)
+        const rightPos = Position.create(...diagnostics[index].end)
+
+        const diagnostic = Diagnostic.create(
+            Range.create(leftPos, rightPos),
+            diagnostics[index].message,
+            DiagnosticSeverity.Error
+        )
+
+        assert.deepStrictEqual(diagnostic, item)
+    })
+}
+
+suite('ASL YAML context-aware validation', () => {
+    suite('Invalid JSON Input', () => {
+        test("Empty string doesn't throw errors", async () => {
+            await getValidations('')
+        })
+
+        test("[] string doesn't throw type errors", async () => {
+            await assert.doesNotReject(getValidations('[]'), TypeError)
+        })
+    })
+
+    suite('Default of Choice state', () => {
+        test('Shows diagnostic for invalid state name', async () => {
+            await testValidations({
+                json: documentChoiceInvalidDefault,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_DEFAULT,
+                        start: [13, 15],
+                        end: [13, 33],
+                    },
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [18, 4],
+                        end: [18, 16],
+                    },
+                ],
+            })
+        })
+
+        test("Doesn't show Diagnostic for valid state name", async () => {
+            await testValidations({
+                json: documentChoiceValidDefault,
+                diagnostics: [],
+            })
+        })
+
+        test("Doesn't show Diagnostic when default property is absent", async () => {
+            await testValidations({
+                json: documentChoiceNoDefault,
+                diagnostics: [],
+            })
+        })
+
+        test("Doesn't show Diagnostic for valid state name when default state is declared before Choice state", async () => {
+            await testValidations({
+                json: documentChoiceDefaultBeforeChoice,
+                diagnostics: [],
+            })
+        })
+    })
+
+    suite('StartAt', () => {
+        test("Shows Diagnostic for state name that doesn't exist", async () => {
+            await testValidations({
+                json: documentStartAtInvalid,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_START_AT,
+                        start: [1, 11],
+                        end: [1, 16],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+
+        test("Doesn't show Diagnostic for valid state name", async () => {
+            await testValidations({
+                json: documentStartAtValid,
+                diagnostics: [],
+            })
+        })
+
+        test("Shows Diagnostic for state name that doesn't exist in nested StartAt property", async () => {
+            await testValidations({
+                json: documentStartAtNestedInvalid,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_START_AT,
+                        start: [7, 19],
+                        end: [7, 22],
+                    },
+                    {
+                        message: MESSAGES.INVALID_START_AT,
+                        start: [21, 19],
+                        end: [21, 23],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+    })
+
+    suite('Next', () => {
+        test("Shows Diagnostic for state name that doesn't exist", async () => {
+            await testValidations({
+                json: documentInvalidNext,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [5, 12],
+                        end: [5, 16],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+
+        test("Doesn't show Diagnostic for valid state name", async () => {
+            await testValidations({
+                json: documentValidNext,
+                diagnostics: [],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+
+        test("Shows Diagnostic for state name that doesn't exist in nested Next property", async () => {
+            await testValidations({
+                json: documentInvalidNextNested,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [11, 20],
+                        end: [11, 31],
+                    },
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [31, 18],
+                        end: [31, 29],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+
+        test('Validates next property of the Choice state', async () => {
+            await testValidations({
+                json: documentChoiceInvalidNext,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [17, 24],
+                        end: [17, 26],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+    })
+
+    suite('Unreachable State', () => {
+        test('Shows diagnostic for an unreachable state', async () => {
+            await testValidations({
+                json: documentUnreachableState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [3, 4],
+                        end: [3, 11],
+                    },
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [12, 4],
+                        end: [12, 14],
+                    },
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [15, 4],
+                        end: [15, 15],
+                    },
+                ],
+                filterMessages: [MESSAGES.NO_TERMINAL_STATE, MESSAGES.INVALID_START_AT],
+            })
+        })
+
+        test('Shows diagnostic for an unreachable state in nested list of states', async () => {
+            await testValidations({
+                json: documentNestedUnreachableState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [12, 12],
+                        end: [12, 18],
+                    },
+                    {
+                        message: MESSAGES.UNREACHABLE_STATE,
+                        start: [32, 10],
+                        end: [32, 16],
+                    },
+                ],
+                filterMessages: [MESSAGES.NO_TERMINAL_STATE],
+            })
+        })
+    })
+
+    suite('Terminal State', () => {
+        test('Shows diagnostic for lack of terminal state', async () => {
+            await testValidations({
+                json: documentNoTerminalState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.NO_TERMINAL_STATE,
+                        start: [2, 2],
+                        end: [2, 8],
+                    },
+                ],
+            })
+        })
+
+        test('Shows diagnostic for lack of terminal state in nested list of states', async () => {
+            await testValidations({
+                json: documentNestedNoTerminalState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.NO_TERMINAL_STATE,
+                        start: [16, 10],
+                        end: [16, 16],
+                    },
+                    {
+                        message: MESSAGES.NO_TERMINAL_STATE,
+                        start: [28, 8],
+                        end: [28, 14],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+
+        test('Accepts "Succeed" and "Fail" state as terminal states', async () => {
+            await testValidations({
+                json: documentSucceedFailTerminalState,
+                diagnostics: [],
+            })
+        })
+
+        test('No terminal state error when state referenced from next property of Choice state within Parallel state', async () => {
+            await testValidations({
+                json: documentChoiceValidNext,
+                diagnostics: [],
+            })
+        })
+    })
+
+    suite('Catch property of "Parallel" and "Task" state', async () => {
+        test('Does not show diagnostic on valid next property within Catch block of Task state', async () => {
+            await testValidations({
+                json: documentTaskCatchTemplate,
+                diagnostics: [],
+            })
+        })
+
+        test('Does not show diagnostic on valid next property within Catch block of Parallel state', async () => {
+            await testValidations({
+                json: documentParallelCatchTemplate,
+                diagnostics: [],
+            })
+        })
+
+        test('Does not show diagnostic on valid next property within Catch block of Map state', async () => {
+            await testValidations({
+                json: documentMapCatchTemplate,
+                diagnostics: [],
+            })
+        })
+
+        test('Shows diagnostics on invalid next property within Catch block of Task state', async () => {
+            await testValidations({
+                json: documentTaskCatchTemplateInvalidNext,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [13, 18],
+                        end: [13, 30],
+                    },
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [16, 18],
+                        end: [16, 34],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+
+        test('Shows diagnostics on invalid next property within Catch block of Parallel', async () => {
+            await testValidations({
+                json: documentParallelCatchTemplateInvalidNext,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [9, 16],
+                        end: [9, 24],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+
+        test('Shows diagnostics on invalid next property within Catch block of Map', async () => {
+            await testValidations({
+                json: documentMapCatchTemplateInvalidNext,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [19, 16],
+                        end: [19, 23],
+                    },
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [25, 16],
+                        end: [25, 24],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+    })
+
+    suite('Additional properties that are not valid', async () => {
+        test('Shows diagnostics for additional invalid properties of a given state', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [7, 6],
+                        end: [7, 23],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [8, 6],
+                        end: [8, 23],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within Catch block', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesCatch,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [10, 8],
+                        end: [10, 18],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [14, 8],
+                        end: [14, 18],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [15, 8],
+                        end: [15, 20],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE],
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within Choice state', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesChoices,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [15, 8],
+                        end: [15, 24],
+                    },
+                    {
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES,
+                        start: [13, 8],
+                        end: [13, 20],
+                    },
+                    {
+                        message: MESSAGES.MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES,
+                        start: [14, 8],
+                        end: [14, 32],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [21, 10],
+                        end: [21, 27],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [22, 10],
+                        end: [22, 14],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [26, 10],
+                        end: [26, 26],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [27, 10],
+                        end: [27, 14],
+                    },
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [32, 8],
+                        end: [32, 12],
+                    },
+                ],
+                filterMessages: [MESSAGES.UNREACHABLE_STATE, JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG],
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within root of state machine', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesRoot,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [5, 2],
+                        end: [5, 18],
+                    },
+                ],
+            })
+        })
+
+        test('Shows diagnostics for additional invalid properties within root of nested state machine', async () => {
+            await testValidations({
+                json: documentInvalidPropertiesRootNested,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_PROPERTY_NAME,
+                        start: [10, 8],
+                        end: [10, 19],
+                    },
+                ],
+            })
+        })
+    })
+
+    suite('Test validation of Resource arn for Task State', async () => {
+        test('Does not show diagnostic on invalid arn', async () => {
+            await testValidations({
+                json: documentTaskInvalidArn,
+                diagnostics: [],
+            })
+        })
+
+        test('Does not show diagnostic on valid variable substitution', async () => {
+            await testValidations({
+                json: documentTaskValidVariableSubstitution,
+                diagnostics: [],
+            })
+        })
+    })
+
+    suite('Test validation of Properties field', async () => {
+        test('Does not show diagnostics for valid JSON paths', async () => {
+            await testValidations({
+                json: documentValidParametersJsonPath,
+                diagnostics: [],
+            })
+        })
+
+        test('Does not show diagnostics for valid Intrinsic Functions', async () => {
+            await testValidations({
+                json: documentValidParametersIntrinsicFunction,
+                diagnostics: [],
+            })
+        })
+
+        test('Shows diagnostics for invalid JSON paths', async () => {
+            await testValidations({
+                json: documentInvalidParametersJsonPath,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [9, 18],
+                        end: [9, 18],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [12, 28],
+                        end: [12, 30],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [13, 28],
+                        end: [13, 32],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [14, 21],
+                        end: [14, 28],
+                    },
+                ],
+            })
+        })
+
+        test('Shows diagnostics for invalid Intrinsic Functions', async () => {
+            await testValidations({
+                json: documentInvalidParametersIntrinsicFunction,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [9, 20],
+                        end: [9, 72],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [10, 20],
+                        end: [10, 43],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [11, 20],
+                        end: [11, 52],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [12, 20],
+                        end: [12, 30],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [13, 20],
+                        end: [13, 37],
+                    },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [14, 20],
+                        end: [14, 38],
+                    },
+                ],
+            })
+        })
+    })
+
+    suite('ASL Improvements', async () => {
+        test('Does not show diagnostics for valid document containing ASL Improvements', async () => {
+            await testValidations({
+                json: documentValidAslImprovements,
+                diagnostics: [],
+            })
+        })
+
+        suite('Test validation of ResultSelector field', async () => {
+            test('Does not show diagnostics for valid JSON paths', async () => {
+                await testValidations({
+                    json: documentValidResultSelectorJsonPath,
+                    diagnostics: [],
+                })
+            })
+
+            test('Does not show diagnostics for valid Intrinsic Functions', async () => {
+                await testValidations({
+                    json: documentValidResultSelectorIntrinsicFunction,
+                    diagnostics: [],
+                })
+            })
+
+            test('Shows diagnostics for invalid JSON paths', async () => {
+                await testValidations({
+                    json: documentInvalidResultSelectorJsonPath,
+                    diagnostics: [
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [9, 18],
+                            end: [9, 18],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [12, 28],
+                            end: [12, 30],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [13, 28],
+                            end: [13, 32],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [14, 21],
+                            end: [14, 28],
+                        },
+                    ],
+                })
+            })
+
+            test('Shows diagnostics for invalid Intrinsic Functions', async () => {
+                await testValidations({
+                    json: documentInvalidResultSelectorIntrinsicFunction,
+                    diagnostics: [
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [9, 20],
+                            end: [9, 72],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [10, 20],
+                            end: [10, 43],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [11, 20],
+                            end: [11, 52],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [12, 20],
+                            end: [12, 30],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [13, 20],
+                            end: [13, 37],
+                        },
+                        {
+                            message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                            start: [14, 20],
+                            end: [14, 39],
+                        },
+                    ],
+                })
+            })
+        })
+    })
+})

--- a/src/tests/yamlValidation.test.ts
+++ b/src/tests/yamlValidation.test.ts
@@ -86,7 +86,6 @@ async function testValidations(options: TestValidationOptions) {
     const { json, diagnostics, filterMessages } = options
 
     let res = await getValidations(json)
-    console.log(res)
     res = res.filter(diagnostic => {
         if (filterMessages && filterMessages.find(message => message === diagnostic.message)) {
             return false
@@ -114,7 +113,7 @@ async function testValidations(options: TestValidationOptions) {
 suite('ASL YAML context-aware validation', () => {
     suite('Invalid JSON Input', () => {
         test("Empty string doesn't throw errors", async () => {
-            await getValidations('')
+            await assert.doesNotReject(getValidations(''))
         })
 
         test("[] string doesn't throw type errors", async () => {

--- a/src/tests/yamlValidation.test.ts
+++ b/src/tests/yamlValidation.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as assert from 'assert'
+import { MESSAGES } from '../constants/diagnosticStrings'
 import { Diagnostic, DiagnosticSeverity, getYamlLanguageService, Position, Range } from '../service'
 
 import {
@@ -51,19 +52,6 @@ import {
 import { toDocument } from './utils/testUtilities'
 
 const JSON_SCHEMA_MULTIPLE_SCHEMAS_MSG = 'Matches multiple schemas when only one must validate.'
-
-const MESSAGES = {
-    INVALID_NEXT: 'The value of "Next" property must be the name of an existing state.',
-    INVALID_DEFAULT: 'The value of "Default" property must be the name of an existing state.',
-    INVALID_START_AT: 'The value of "StartAt" property must be the name of an existing state.',
-    INVALID_JSON_PATH_OR_INTRINSIC:
-        'The value for the field must be a valid JSONPath or intrinsic function expression.',
-    UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
-    NO_TERMINAL_STATE:
-        'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
-    INVALID_PROPERTY_NAME: 'Field is not supported.',
-    MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.',
-} as const
 
 export interface TestValidationOptions {
     json: string

--- a/src/tests/yasl-strings/validationStrings.ts
+++ b/src/tests/yasl-strings/validationStrings.ts
@@ -1,0 +1,1100 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+export const documentStartAtInvalid = `
+  StartAt: First
+  States:
+    FirstState:
+      Type: Pass
+      End: true
+`
+
+export const documentStartAtValid = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Pass
+      End: true
+`
+
+export const documentStartAtNestedInvalid = `
+  StartAt: LookupCustomerInfo
+  States:
+    LookupCustomerInfo:
+      Type: Parallel
+      End: true
+      Branches:
+        - StartAt: Loo
+          States:
+            LookupAddress:
+              Type: Pass
+              End: true
+        - StartAt: LookupPhone
+          States:
+            LookupPhone:
+              Type: Pass
+              End: true
+    Validate-All:
+      Type: Map
+      ItemsPath: $.items
+      Iterator:
+          StartAt: Vali
+          States:
+              Validate:
+                  Type: Pass
+                  End: true
+      End: true
+`
+
+export const documentInvalidNext = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Pass
+      Next: Next
+    NextState:
+      Type: Pass
+      End: true
+`
+
+export const documentValidNext = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Pass
+      Next: NextState
+    NextState:
+      Type: Pass
+      End: true
+`
+
+export const documentInvalidNextNested = `
+  StartAt: LookupCustomerInfo
+  States:
+    LookupCustomerInfo:
+      Type: Parallel
+      End: true
+      Branches:
+        - StartAt: LookupAddress
+          States:
+            LookupAddress:
+              Type: Pass
+              Next: InvalidName
+            Second:
+              Type: Pass
+              End: true
+        - StartAt: LookupPhone
+          States:
+            LookupPhone:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Pass
+              End: true
+    Validate-All:
+      Type: Map
+      ItemsPath: $.items
+      Iterator:
+        StartAt: Validate
+        States:
+          Validate:
+            Type: Pass
+            Next: InvalidName
+          Second:
+            Type: Pass
+            End: true
+      End: true
+`
+
+export const documentUnreachableState = `
+  StartAt: FirstS
+  States:
+    AndHere:
+      Type: Pass
+      Next: FirstState
+    FirstState:
+      Type: Pass
+      Next: SecondState
+    SecondState:
+      Type: Pass
+      End: true
+    ThirdState:
+      Type: Pass
+      End: true
+    FourthState:
+      Type: Pass
+      End: true
+`
+
+export const documentNestedUnreachableState = `
+  StartAt: LookupCustomerInfo
+  States:
+    LookupCustomerInfo:
+      Type: Parallel
+      Next: Validate-All
+      Branches:
+        - StartAt: LookupAddress
+          States:
+            LookupAddress:
+              Type: Pass
+              End: true
+            Second:
+              Type: Pass
+              End: true
+        - StartAt: LookupPhone
+          States:
+            LookupPhone:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Pass
+              End: true
+    Validate-All:
+      Type: Map
+      ItemsPath: $.items
+      Iterator:
+        StartAt: Validate
+        States:
+          Validate:
+            Type: Pass
+            End: true
+          Second:
+            Type: Pass
+            End: true
+      End: true
+`
+
+export const documentNoTerminalState = `
+  StartAt: FirstState
+  States:
+    AndHere:
+      Type: Pass
+      Next: SecondState
+    FirstState:
+      Type: Pass
+      Next: SecondState
+    SecondState:
+      Type: Pass
+      Next: AndHere
+  `
+
+export const documentNestedNoTerminalState = `
+  StartAt: LookupCustomerInfo
+  States:
+    LookupCustomerInfo:
+      Type: Parallel
+      Next: Validate-All
+      Branches:
+        - StartAt: LookupAddress
+          States:
+            LookupAddress:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Pass
+              End: true
+        - StartAt: LookupPhone
+          States:
+            LookupPhone:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Pass
+              Next: LookupPhone
+    Validate-All:
+      Type: Map
+      ItemsPath: $.items
+      Iterator:
+        StartAt: Validate
+        States:
+          Validate:
+            Type: Pass
+            Next: Second
+          Second:
+            Type: Pass
+            Next: Third
+          Third:
+            Type: Pass
+            Next: Validate
+      End: true
+`
+
+export const documentSucceedFailTerminalState = `
+  StartAt: LookupCustomerInfo
+  States:
+    LookupCustomerInfo:
+      Type: Parallel
+      Next: Validate-All
+      Branches:
+        - StartAt: LookupAddress
+          States:
+            LookupAddress:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Succeed
+        - StartAt: LookupPhone
+          States:
+            LookupPhone:
+              Type: Pass
+              Next: Second
+            Second:
+              Type: Fail
+    Validate-All:
+      Type: Map
+      ItemsPath: $.items
+      Iterator:
+        StartAt: Validate
+        States:
+          Validate:
+            Type: Pass
+            Next: Second
+          Second:
+            Type: Pass
+            Next: Third
+          Third:
+            Type: Succeed
+      End: true
+`
+
+export const documentTaskValidVariableSubstitution = `
+  Comment: A Catch example of the Amazon States Language using an AWS Lambda Function
+  StartAt: HelloWorld
+  States:
+    HelloWorld:
+      Type: Task
+      Resource: \$variableName
+      End: true
+`
+
+export const documentTaskInvalidArn = `
+  Comment: A Catch example of the Amazon States Language using an AWS Lambda Function
+  StartAt: HelloWorld
+  States:
+    HelloWorld:
+      Type: Task
+      Resource: InvalidArn
+      End: true
+`
+
+export const documentTaskCatchTemplate = `
+  Comment: A Catch example of the Amazon States Language using an AWS Lambda Function
+  StartAt: HelloWorld
+  States:
+    HelloWorld:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:myFunction
+      Catch:
+        - ErrorEquals:
+            - CustomError
+          Next: CustomErrorFallback
+        - ErrorEquals:
+            - States.TaskFailed
+          Next: ReservedTypeFallback
+        - ErrorEquals:
+            - States.ALL
+          Next: CatchAllFallback
+      End: true
+    CustomErrorFallback:
+      Type: Pass
+      Result: This is a fallback from a custom lambda function exception
+      End: true
+    ReservedTypeFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+    CatchAllFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+`
+
+export const documentParallelCatchTemplate = `
+  StartAt: Parallel
+  States:
+    Parallel:
+      Type: Parallel
+      Next: Final State
+      Catch:
+        - ErrorEquals:
+            - States.ALL
+          Next: CatchState
+      Branches:
+        - StartAt: Wait 20s
+          States:
+            Wait 20s:
+              Type: Wait
+              Seconds: 20
+              End: true
+    Final State:
+      Type: Pass
+      End: true
+    CatchState:
+      Type: Pass
+      End: true
+`
+
+export const documentMapCatchTemplate = `
+  StartAt: Map
+  States:
+    Map:
+      Type: Map
+      ItemsPath: $.array
+      ResultPath: $.array
+      MaxConcurrency: 2
+      Next: Final State
+      Iterator:
+          StartAt: Pass
+          States:
+              Pass:
+                  Type: Pass
+                  Result: Done!
+                  End: true
+      Catch:
+        - ErrorEquals:
+            - CustomError
+          Next: CustomErrorFallback
+        - ErrorEquals:
+            - States.TaskFailed
+          Next: ReservedTypeFallback
+        - ErrorEquals:
+            - States.ALL
+          Next: CatchAllFallback
+    Final State:
+      Type: Pass
+      End: true
+    CustomErrorFallback:
+      Type: Pass
+      Result: This is a fallback from a custom lambda function exception
+      End: true
+    ReservedTypeFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+    CatchAllFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+`
+
+export const documentMapCatchTemplateInvalidNext = `
+  StartAt: Map
+  States:
+    Map:
+      Type: Map
+      ItemsPath: $.array
+      ResultPath: $.array
+      MaxConcurrency: 2
+      Next: Final State
+      Iterator:
+        StartAt: Pass
+        States:
+          Pass:
+              Type: Pass
+              Result: Done!
+              End: true
+      Catch:
+        - ErrorEquals:
+            - CustomError
+          Next: invalid
+        - ErrorEquals:
+            - States.TaskFailed
+          Next: ReservedTypeFallback
+        - ErrorEquals:
+            - States.ALL
+          Next: invalid2
+    Final State:
+      Type: Pass
+      End: true
+    CustomErrorFallback:
+      Type: Pass
+      Result: This is a fallback from a custom lambda function exception
+      End: true
+    ReservedTypeFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+    CatchAllFallback:
+      Type: Pass
+      Result: This is a fallback from a reserved error code
+      End: true
+`
+
+export const documentTaskCatchTemplateInvalidNext = `
+  Comment: A Catch example of the Amazon States Language using an AWS Lambda Function
+  StartAt: HelloWorld
+  States:
+    HelloWorld:
+        Type: Task
+        Resource: arn:aws:lambda:us-east-1:111111111111:function:myFunction
+        Catch:
+          - ErrorEquals:
+            - CustomError
+            Next: CustomErrorFallback
+          - ErrorEquals:
+            - States.TaskFailed
+            Next: ReservedType
+          - ErrorEquals:
+              - States.ALL
+            Next: CatchAllFallback
+        End: true
+    CustomErrorFallback:
+      Type: Pass
+      Result: This is a fallback from a custom lambda function exception
+      End: true
+`
+
+export const documentParallelCatchTemplateInvalidNext = `
+  StartAt: Parallel
+  States:
+    Parallel:
+      Type: Parallel
+      Next: Final State
+      Catch:
+        - ErrorEquals:
+          - States.ALL
+          Next: Catchddd
+      Branches:
+        - StartAt: Wait 20s
+          States:
+            Wait 20s:
+              Type: Wait
+              Seconds: 20
+              End: true
+    Final State:
+      Type: Pass
+      End: true
+    CatchState:
+      Type: Pass
+      End: true
+`
+export const documentChoiceValidNext = `
+  StartAt: Parallel
+  States:
+    Parallel:
+      Type: Parallel
+      Next: Final State
+      Branches:
+        - StartAt: FirstState
+          States:
+            FirstState:
+              Type: Pass
+              Next: ChoiceState
+            ChoiceState:
+              Type: Choice
+              Choices:
+                - Variable: $.Comment
+                  NumericEquals: 1
+                  Next: Last
+              Default: FirstState
+            Last:
+              Type: Pass
+              End: true
+    Final State:
+      Type: Pass
+      End: true
+  `
+
+export const documentChoiceInvalidNext = `
+  StartAt: Parallel
+  States:
+    Parallel:
+      Type: Parallel
+      Next: Final State
+      Branches:
+        - StartAt: FirstState
+          States:
+            FirstState:
+              Type: Pass
+              Next: ChoiceState
+            ChoiceState:
+              Type: Choice
+              Choices:
+                - Variable: $.Comment
+                  NumericEquals: 1
+                  Next: La
+              Default: FirstState
+    Final State:
+      Type: Pass
+      End: true
+`
+
+export const documentChoiceValidDefault = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+      Next: ChoiceState
+    ChoiceState:
+      Type: Choice
+      Choices:
+        - Variable: $.foo
+          NumericEquals: 1
+          Next: FirstMatchState
+      Default: DefaultState
+    FirstMatchState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch
+      Next: NextState
+    DefaultState:
+      Type: Fail
+      Error: DefaultStateError
+      Cause: No Matches!
+    NextState:
+      Type: Pass
+      End: true
+`
+
+export const documentChoiceInvalidDefault = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+      Next: ChoiceState
+    ChoiceState:
+      Type: Choice
+      Choices:
+        - Variable: $.foo
+          NumericEquals: 1
+          Next: FirstMatchState
+      Default: DefaultStatexxxxxx
+    FirstMatchState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch
+      Next: NextState
+    DefaultState:
+      Type: Fail
+      Error: DefaultStateError
+      Cause: No Matches!
+    NextState:
+      Type: Pass
+      End: true
+`
+
+export const documentChoiceNoDefault = `
+  StartAt: ChoiceState
+  States:
+    ChoiceState:
+      Type: Choice
+      Choices:
+        - Variable: $.foo
+          NumericEquals: 1
+          Next: FirstMatchState
+    FirstMatchState:
+      Type: Pass
+      End: true
+`
+
+export const documentChoiceDefaultBeforeChoice = `
+  StartAt: ChoiceState
+  States:
+    DefaultState:
+      Type: Fail
+      Error: DefaultStateError
+      Cause: No Matches!
+    ChoiceState:
+      Type: Choice
+      Choices:
+        - Variable: $.foo
+          NumericEquals: 1
+          Next: FirstMatchState
+      Default: DefaultState
+    FirstMatchState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch
+      End: true
+`
+
+export const documentInvalidPropertiesState = `
+  StartAt: FirstState
+  States:
+    FirstState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+      Next: ChoiceState
+      SomethingInvalid1: dddd
+      SomethingInvalid2: eeee
+    ChoiceState:
+      Type: Choice
+      Choices:
+        - Variable: $.foo
+          NumericEquals: 1
+          Next: FirstMatchState
+      Default: DefaultState
+    FirstMatchState:
+      Type: Task
+      Resource: arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch
+      Next: NextState
+    DefaultState:
+      Type: Fail
+      Error: DefaultStateError
+      Cause: No Matches!
+    NextState:
+      Type: Pass
+      End: true
+`
+
+export const documentInvalidPropertiesCatch = `
+StartAt: HelloWorld
+States:
+  HelloWorld:
+    Type: Task
+    Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+    Catch:
+      - ErrorEquals:
+          - CustomError
+        Next: CustomErrorFallback
+        OneInvalid: something
+      - ErrorEquals:
+          - States.TaskFailed
+        Next: ReservedTypeFallback
+        TwoInvalid: something
+        ThreeInvalid: something
+      - ErrorEquals:
+          - States.ALL
+        Next: CatchAllFallback
+    End: true
+
+  CustomErrorFallback:
+    Type: Pass
+    Result: This is a fallback from a custom lambda function exception
+    End: true
+
+  ReservedTypeFallback:
+    Type: Pass
+    Result: This is a fallback from a reserved error code
+    End: true
+
+  CatchAllFallback:
+    Type: Pass
+    Result: This is a fallback from a reserved error code
+    End: true
+`
+
+export const documentInvalidPropertiesChoices = `
+Comment: An example of the Amazon States Language using a choice state.
+StartAt: FirstState
+States:
+  FirstState:
+    Type: Task
+    Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+    Next: ChoiceState
+  ChoiceState:
+    Type: Choice
+    Choices:
+    - Not:
+        Variable: "$.foo"
+        StringEquals: blabla
+        NumericGreaterThanEquals: 20
+        FirstInvalidProp:
+      Next: FirstMatchState
+    - And:
+      - Not:
+          Variable: "$.foo"
+          StringEquals: blabla
+          SecondInvalidProp:
+          Next: FirstMatchState
+      - Or:
+        - Variable: "$.value"
+          NumericGreaterThanEquals: 20
+          ThirdInvalidProp:
+          Next: FirstMatchState
+        - Variable: "$.value"
+          NumericLessThan: 30
+      - Variable: "$.foo"
+        NumericGreaterThanEquals: 20
+        Next: SecondMatchState
+      Next: SecondMatchState
+    Default: DefaultState
+  FirstMatchState:
+    Type: Task
+    Resource: arn:aws:lambda:us-east-1:111111111111:function:OnFirstMatch
+    Next: NextState
+  SecondMatchState:
+    Type: Task
+    Resource: arn:aws:lambda:us-east-1:111111111111:function:OnSecondMatch
+    Next: NextState
+  DefaultState:
+    Type: Fail
+    Error: DefaultStateError
+    Cause: No Matches!
+  NextState:
+    Type: Task
+    Resource: arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME
+    End: true
+`
+export const documentInvalidPropertiesRoot = `
+  StartAt: Succeed
+  TimeoutSeconds: 3
+  Version: "1.0"
+  Comment: It's a test
+  NewTopLevelField: This field is not supported
+  States:
+    Succeed:
+      Type: Succeed
+`
+export const documentInvalidPropertiesRootNested = `
+  StartAt: Map
+  States:
+    Map:
+      Type: Map
+      ItemsPath: $.array
+      Next: Final State
+      Iterator:
+        StartAt: Pass
+        Comment: Nested comment
+        InvalidProp: This is invalid
+        States:
+          Pass:
+            Type: Pass
+            Result: Done!
+            End: true
+    Final State:
+      Type: Pass
+      End: true
+`
+
+export const documentValidParametersJsonPath = `
+  StartAt: GetManualReview
+  States:
+    GetManualReview:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
+      Parameters:
+        FunctionName: get-model-review-decision
+        Payload:
+          model.$: $.new_model
+          token.$: $$.Task.Token
+          someProp:
+            nested_model.$: $.new_model
+            nested_token.$: $$.Task.Token
+        Qualifier: prod-v1
+      End: true
+`
+
+export const documentInvalidParametersJsonPath = `
+  StartAt: GetManualReview
+  States:
+    GetManualReview:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
+      Parameters:
+        FunctionName: get-model-review-decision
+        Payload:
+          model.$:
+          token.$: $$.Task.Token
+          someProp:
+            nested_model.$: 22
+            nested_token.$: true
+        Qualifier.$: prod-v1
+      End: true
+`
+export const documentValidParametersIntrinsicFunction = `
+  StartAt: Invoke Lambda function
+  States:
+    Invoke Lambda function:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+        Payload:
+          Input1.$: States.Format($.template $.firstName $.lastName)
+          Input2.$: States.JsonToString($)
+          Input3.$: States.StringToJson($.escaped)
+          Input4.$: States.Format($.template $.firstName $.lastName)
+          Input5.$: States.JsonToString($)
+          Input6.$: States.StringToJson($.escaped)
+      Next: Succeed state
+    Succeed state:
+      Type: Succeed
+`
+
+export const documentInvalidParametersIntrinsicFunction = `
+  StartAt: Invoke Lambda function
+  States:
+    Invoke Lambda function:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+        Payload:
+          Input1.$: "  States.Format($.template $.firstName $.lastName)"
+          Input2.$: "States.JsonToString($"
+          Input3.$: "States.StringToJson $.escaped)"
+          Input4.$: "States. "
+          Input5.$: "JsonToString($)"
+          Input6.$: "something else  "
+      Next: Succeed state
+    Succeed state:
+      Type: Succeed
+`
+
+export const documentValidAslImprovements = `
+  StartAt: Invoke Lambda function
+  States:
+    Invoke Lambda function:
+        Type: Task
+        TimeoutSecondsPath: $.path
+        HeartbeatSecondsPath: $.path
+        InputPath: $$.Execution.Id
+        OutputPath: $$.Execution.Id
+        Resource: arn:aws:states:::lambda:invoke
+        Parameters:
+            FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+            Payload:
+              Input.$: $
+        ResultSelector:
+            example.$: $
+            example2:
+              nested.$: $.path
+        Next: MapState
+    MapState:
+        Type: Map
+        ItemsPath: '$.array'
+        MaxConcurrency: 0
+        Iterator:
+          StartAt: Pass
+          States:
+            Pass:
+              Type: Pass
+              Result: Done!
+              End: true
+        ResultSelector:
+            example.$: $
+            example2:
+              nested.$: $.path
+        ResultPath: $.output
+        Next: ParallelState
+    ParallelState:
+        Type: Parallel
+        Branches:
+          - StartAt: State1
+            States:
+                State1:
+                  Type: Pass
+                  End: true
+          - StartAt: State2
+            States:
+                State2:
+                  Type: Pass
+                  End: true
+        ResultSelector:
+            example.$: $
+            example2:
+              nested.$: $.path
+        Next: Compare 2 variables
+
+    Compare 2 variables:
+        Type: Choice
+        Choices:
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsNull: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsPresent: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsNumeric: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsString: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsBoolean: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            IsTimestamp: true
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringMatches: uuu*
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringLessThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringGreaterThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringLessThanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            StringGreaterThanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            NumericEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            NumericLessThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            NumericGreaterThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            NumericLessThanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            NumericGreaterThanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            BooleanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            TimestampEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            TimestampLessThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            TimestampGreaterThanPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            TimestampLessThanEqualsPath: $.some.path
+          - Variable: $.var1
+            Next: "Succeed state"
+            TimestampGreaterThanEqualsPath: $.some.path
+          - And:
+            - Variable: $.var1
+              IsNull: true
+            - Variable: $.var1
+              IsPresent: true
+            - Variable: $.var1
+              IsNumeric: true
+            - Variable: $.var1
+              IsString: true
+            - Variable: $.var1
+              IsBoolean: true
+            - Variable: $.var1
+              IsTimestamp: true
+            - Variable: $.var1
+              StringMatches: uuu*
+            - Variable: $.var1
+              StringEqualsPath: $.some.path
+            - Variable: $.var1
+              StringLessThanPath: $.some.path
+            - Variable: $.var1
+              StringGreaterThanPath: $.some.path
+            - Variable: $.var1
+              StringLessThanEqualsPath: $.some.path
+            - Variable: $.var1
+              StringGreaterThanEqualsPath: $.some.path
+            - Variable: $.var1
+              NumericEqualsPath: $.some.path
+            - Variable: $.var1
+              NumericLessThanPath: $.some.path
+            - Variable: $.var1
+              NumericGreaterThanPath: $.some.path
+            - Variable: $.var1
+              NumericLessThanEqualsPath: $.some.path
+            - Variable: $.var1
+              NumericGreaterThanEqualsPath: $.some.path
+            - Variable: $.var1
+              BooleanEqualsPath: $.some.path
+            - Variable: $.var1
+              TimestampEqualsPath: $.some.path
+            - Variable: $.var1
+              TimestampLessThanPath: $.some.path
+            - Variable: $.var1
+              TimestampGreaterThanPath: $.some.path
+            - Variable: $.var1
+              TimestampLessThanEqualsPath: $.some.path
+            - Variable: $.var1
+              TimestampGreaterThanEqualsPath: $.some.path
+            Next: "Succeed state"
+        Default: Fail state
+    Fail state:
+        Type: Fail
+    "Succeed state":
+        Type: Succeed
+`
+
+export const documentValidResultSelectorJsonPath = `
+  StartAt: GetManualReview
+  States:
+    GetManualReview:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
+      ResultSelector:
+        prop1: get-model-review-decision
+        prop2:
+          model.$: $.new_model
+          token.$: $$.Task.Token
+          someProp:
+            nested_model.$: $.new_model
+            nested_token.$: $$.Task.Token
+        Qualifier: prod-v1
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+      End: true
+`
+
+export const documentInvalidResultSelectorJsonPath = `
+  StartAt: GetManualReview
+  States:
+    GetManualReview:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke.waitForTaskToken
+      ResultSelector:
+        prop1: get-model-review-decision
+        prop2:
+          model.$:
+          token.$: $$.Task.Token
+          someProp:
+            nested_model.$: 22
+            nested_token.$: true
+        Qualifier.$: prod-v1
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+      End: true
+`
+
+export const documentValidResultSelectorIntrinsicFunction = `
+  StartAt: Invoke Lambda function
+  States:
+    Invoke Lambda function:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke
+      ResultSelector:
+        prop1: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+        prop2:
+          Input1.$: "States.Format($.template $.firstName $.lastName)"
+          Input2.$: "States.JsonToString($)"
+          Input3.$: "States.StringToJson($.escaped)"
+          Input4.$: "States.Format($.template $.firstName $.lastName)  "
+          Input5.$: "States.JsonToString($)   "
+          Input6.$: "States.StringToJson($.escaped)   "
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+      Next: Succeed state
+    Succeed state:
+      Type: Succeed
+`
+
+export const documentInvalidResultSelectorIntrinsicFunction = `
+  StartAt: Invoke Lambda function
+  States:
+    Invoke Lambda function:
+      Type: Task
+      Resource: arn:aws:states:::lambda:invoke
+      ResultSelector:
+        prop1: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+        prop2:
+          Input1.$: "  States.Format($.template $.firstName $.lastName)"
+          Input2.$: "States.JsonToString($"
+          Input3.$: "States.StringToJson $.escaped)"
+          Input4.$: "States. "
+          Input5.$: "JsonToString($)"
+          Input6.$: "something else   "
+      Parameters:
+        FunctionName: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+      Next: Succeed state
+    Succeed state:
+      Type: Succeed
+`

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -63,7 +63,7 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
 
         for (const currentYAMLDoc of yamlDocument.documents) {
             const validation = await aslLanguageService.doValidation(textDocument, currentYAMLDoc)
-            const syd = ((currentYAMLDoc as unknown) as any) as SingleYAMLDocument
+            const syd = (currentYAMLDoc as unknown) as SingleYAMLDocument
             if (syd.errors.length > 0) {
                 validationResult.push(...syd.errors)
             }
@@ -137,7 +137,6 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
                 if (completion.textEdit) {
                     // textEdit can't be done on white-space so insert text is used instead
                     if (atSpace) {
-                        completion.insertText = completion.textEdit.newText
                         // remove any commas from json-completions
                         completion.insertText = completion.textEdit.newText.replace(/[\,]/g, '')
                         completion.textEdit = undefined
@@ -172,7 +171,11 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
         return aslLanguageService.doHover(document, position, currentDoc)
     }
 
-    languageService.format = function(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+    languageService.format = function(
+        document: TextDocument,
+        range: Range,
+        options: FormattingOptions
+    ): TextEdit[] {
         try {
             const text = document.getText()
 

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -54,9 +54,7 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
     const completer = new YAMLCompletion(schemaService)
 
     languageService.doValidation = async function(
-        textDocument: TextDocument,
-        jsonDocument: JSONDocument,
-        documentSettings: DocumentLanguageSettings
+        textDocument: TextDocument
     ) {
         const yamlDocument: YAMLDocument = parseYAML(textDocument.getText())
         const validationResult: any[] = []
@@ -79,8 +77,7 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
 
     languageService.doComplete = async function(
         document: TextDocument,
-        position: Position,
-        doc: JSONDocument
+        position: Position
     ): Promise<CompletionList> {
         const yamldoc = parseYAML(document.getText())
         const offset = document.offsetAt(position)
@@ -154,8 +151,7 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
 
     languageService.doHover = function(
         document: TextDocument,
-        position: Position,
-        jsonDocument: JSONDocument
+        position: Position
     ): Thenable<Hover | null> {
         const doc = parseYAML(document.getText())
         const offset = document.offsetAt(position)
@@ -172,9 +168,7 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
     }
 
     languageService.format = function(
-        document: TextDocument,
-        range: Range,
-        options: FormattingOptions
+        document: TextDocument
     ): TextEdit[] {
         try {
             const text = document.getText()

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -1,0 +1,228 @@
+/*!
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as prettier from 'prettier'
+import {
+    DocumentLanguageSettings,
+    getLanguageService as getLanguageServiceVscode,
+    JSONDocument,
+    JSONSchema,
+    LanguageService,
+    LanguageServiceParams,
+} from 'vscode-json-languageservice'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import {
+    CompletionList,
+    DocumentSymbol,
+    FormattingOptions,
+    Hover,
+    Position,
+    Range,
+    SymbolInformation,
+    TextEdit
+} from 'vscode-languageserver-types'
+import {
+    parse as parseYAML,
+    SingleYAMLDocument,
+    YAMLDocument,
+} from 'yaml-language-server/out/server/src/languageservice/parser/yamlParser07'
+import { YAMLCompletion } from 'yaml-language-server/out/server/src/languageservice/services/yamlCompletion'
+import { YAMLSchemaService } from 'yaml-language-server/out/server/src/languageservice/services/yamlSchemaService'
+import { matchOffsetToDocument } from 'yaml-language-server/out/server/src/languageservice/utils/arrUtils'
+import doCompleteAsl from '../completion/completeAsl'
+
+export const getLanguageService = function(params: LanguageServiceParams, schema: JSONSchema, aslLanguageService: LanguageService): LanguageService {
+    const builtInParams = {}
+
+    const languageService = getLanguageServiceVscode({
+        ...params,
+        ...builtInParams,
+    })
+
+    const requestServiceMock = async function(uri: string): Promise<string> {
+        return new Promise<string>(c => {
+            c(JSON.stringify(schema))
+        })
+    }
+    const schemaService = new YAMLSchemaService(requestServiceMock, params.workspaceContext)
+    // initialize schema
+    schemaService.registerExternalSchema('yasl', ['*.asl.yaml', '*.asl.yml'], schema)
+    schemaService.getOrAddSchemaHandle('yasl', schema)
+
+    const completer = new YAMLCompletion(schemaService)
+
+    languageService.doValidation = async function(
+        textDocument: TextDocument,
+        jsonDocument: JSONDocument,
+        documentSettings: DocumentLanguageSettings
+    ) {
+        const yamlDocument: YAMLDocument = parseYAML(textDocument.getText())
+        const validationResult: any[] = []
+
+        for (const currentYAMLDoc of yamlDocument.documents) {
+            const validation = await aslLanguageService.doValidation(textDocument, currentYAMLDoc)
+            const syd = ((currentYAMLDoc as unknown) as any) as SingleYAMLDocument
+            if (syd.errors.length > 0) {
+                validationResult.push(...syd.errors)
+            }
+            if (syd.warnings.length > 0) {
+                validationResult.push(...syd.warnings)
+            }
+
+            validationResult.push(...validation)
+        }
+
+        return validationResult
+    }
+
+    languageService.doComplete = async function(
+        document: TextDocument,
+        position: Position,
+        doc: JSONDocument
+    ): Promise<CompletionList> {
+        const yamldoc = parseYAML(document.getText())
+        const offset = document.offsetAt(position)
+        let currentDoc = matchOffsetToDocument(offset, yamldoc)
+        let atSpace = false
+
+        // if a yaml doc is null, it must be given text to allow auto-completion
+        if (!currentDoc) {
+            currentDoc = initializeDocument(document, offset)
+            // move cursor position into new empty object
+            position.character += 1
+        }
+
+        const yamlCompletions = await completer.doComplete(document, position, false)
+
+        if (!currentDoc) {
+            return { items: [], isIncomplete: false }
+        }
+        // adjust position for completion
+        const node = currentDoc.getNodeFromOffsetEndInclusive(offset)
+        if (node.type === 'array') {
+            // Resolves issue with array item insert text being off by a space
+            position.character -= 1
+        } else if (document.getText().substring(offset, offset + 1) === '"') {
+            // When attempting to auto-complete from inside an empty string, the position must be adjusted within bounds
+            position.character += 1
+        } else if (document.getText().substring(offset - 2, offset) === ': ') {
+            // yaml doesn't allow auto-completion from white-space after certain nodes
+            atSpace = true
+            // initialize an empty string and adjust position to within the string before parsing yaml to json
+            const newText = `${document.getText().substring(0, offset)}""\n${document.getText().substr(offset)}`
+            const parsedDoc = parseYAML(newText)
+            currentDoc = matchOffsetToDocument(offset, parsedDoc)
+            position.character += 1
+        } else if (node.type === 'property' || (node.type === 'object' && position.character !== 0)) {
+            // allow auto-completion of States field from empty space
+            if (document.getText().substring(offset - 2, offset) === '  ') {
+                atSpace = true
+                currentDoc = initializeDocument(document, offset)
+                // move cursor position into new empty object
+                position.character += 1
+            } else {
+                // adjust cursor back after parsing to keep it within States node
+                position.character -= 1
+            }
+        }
+        if (currentDoc) {
+            const aslCompletions : CompletionList  = doCompleteAsl(document, position, currentDoc, yamlCompletions, {
+                ignoreColonOffset: true,
+            })
+
+            aslCompletions.items.forEach(completion => {
+                // format json completions for yaml
+                if (completion.textEdit) {
+                    // textEdit can't be done on white-space so insert text is used instead
+                    if (atSpace) {
+                        completion.insertText = completion.textEdit.newText
+                        // remove any commas from json-completions
+                        completion.insertText = completion.textEdit.newText.replace(/[\,]/g, '')
+                        completion.textEdit = undefined
+                    } else {
+                        completion.textEdit.range.start.character = position.character
+                    }
+                }
+            })
+
+            return Promise.resolve(aslCompletions)
+        } else {
+            return { items: [], isIncomplete: false }
+        }
+    }
+
+    languageService.doHover = function(
+        document: TextDocument,
+        position: Position,
+        jsonDocument: JSONDocument
+    ): Thenable<Hover | null> {
+        const doc = parseYAML(document.getText())
+        const offset = document.offsetAt(position)
+        const currentDoc = matchOffsetToDocument(offset, doc)
+        if (!currentDoc) {
+            // tslint:disable-next-line: no-null-keyword
+            return Promise.resolve(null)
+        }
+
+        const currentDocIndex = doc.documents.indexOf(currentDoc)
+        currentDoc.currentDocIndex = currentDocIndex
+
+        return aslLanguageService.doHover(document, position, currentDoc)
+    }
+
+    languageService.format = function(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        try {
+            const text = document.getText()
+
+            const formatted = prettier.format(text, { parser: 'yaml' })
+
+            return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)]
+        } catch (error) {
+            return []
+        }
+    }
+
+    languageService.findDocumentSymbols = function(document: TextDocument): SymbolInformation[] {
+        const doc = parseYAML(document.getText())
+        if (!doc || doc.documents.length === 0) {
+            return []
+        }
+
+        let results: any[] = []
+        for (const yamlDoc of doc.documents) {
+            if (yamlDoc.root) {
+                results = results.concat(aslLanguageService.findDocumentSymbols(document, yamlDoc))
+            }
+        }
+
+        return results
+    }
+
+    languageService.findDocumentSymbols2 = function(document: TextDocument): DocumentSymbol[] {
+        const doc = parseYAML(document.getText())
+        if (!doc || doc.documents.length === 0) {
+            return []
+        }
+
+        let results: any[] = []
+        for (const yamlDoc of doc.documents) {
+            if (yamlDoc.root) {
+                results = results.concat(aslLanguageService.findDocumentSymbols2(document, yamlDoc))
+            }
+        }
+
+        return results
+    }
+
+    // initialize brackets to surround the empty space when parsing
+    const initializeDocument = function(text: TextDocument, offset: number) {
+        // tslint:disable-next-line: prefer-template
+        const newText = `${text.getText().substring(0, offset)}{}\r${text.getText().substr(offset)}`
+
+        return matchOffsetToDocument(offset, parseYAML(newText))
+    }
+
+    return languageService
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Moving ASL YAML functionality from the PR for Toolkit (https://github.com/aws/aws-toolkit-vscode/pull/1255, https://github.com/aws/aws-toolkit-vscode/pull/1303) to the Amazon States Language service.
* Modifications made include fixing TS linting issues, and addressing the comments from the Toolkit PR.
* Moved tests here as well.
* Bumping version to 1.5.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
