### PR TITLE
Fixes the yaml snippets not appearing in right places

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
 			"runtimeArgs": [],
 			"env": {},
 			"sourceMaps": true,
-			"outFiles": [ "${workspaceRoot}/server/out/asl-language-service/tests/**/*.js" ],
+			"outFiles": [ "${workspaceRoot}/out/**/*.js", "${workspaceRoot}/out/*.js" ],
 			"preLaunchTask": "npm: watch"
 		}
 	]

--- a/src/completion/completeAsl.ts
+++ b/src/completion/completeAsl.ts
@@ -33,7 +33,7 @@ export default function completeAsl(document: TextDocument, position: Position, 
 
     const node = findNodeAtLocation(rootNode, offset)
 
-    const snippetsList = completeSnippets(node, offset, aslOptions?.forceShowStateSnippets)
+    const snippetsList = completeSnippets(node, offset, aslOptions?.shouldShowStateSnippets)
     let completionList = completeStateNames(node, offset, document, aslOptions) ?? jsonCompletions
 
     if (completionList?.items) {

--- a/src/completion/completeAsl.ts
+++ b/src/completion/completeAsl.ts
@@ -33,7 +33,7 @@ export default function completeAsl(document: TextDocument, position: Position, 
 
     const node = findNodeAtLocation(rootNode, offset)
 
-    const snippetsList = completeSnippets(node)
+    const snippetsList = completeSnippets(node, offset, aslOptions?.forceShowStateSnippets)
     let completionList = completeStateNames(node, offset, document, aslOptions) ?? jsonCompletions
 
     if (completionList?.items) {

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -53,11 +53,16 @@ function doesStateSupportErrorHandling(node: ASTNode): boolean {
     return ERROR_HANDLING_STATES.includes(typeNode?.valueNode?.value as string)
 }
 
-export default function completeSnippets(node: ASTNode | undefined): CompletionItem[] {
+export default function completeSnippets(node: ASTNode | undefined, offset: number, forceShowStateSnippets?: boolean): CompletionItem[] {
     if (node) {
-        if (isChildOfStates(node)) {
+        // If the value of forceShowStateSnippets is false prevent the snippets from being displayed
+        const shouldShowStateSnippets = (isChildOfStates(node) && forceShowStateSnippets !== false)
+            || forceShowStateSnippets
+
+        if (shouldShowStateSnippets) {
             return stateSnippets
         }
+
         if (insideStateNode(node) && doesStateSupportErrorHandling(node)) {
             return errorHandlingSnippets
         }

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -56,7 +56,7 @@ function doesStateSupportErrorHandling(node: ASTNode): boolean {
 export default function completeSnippets(node: ASTNode | undefined, offset: number, shouldShowStateSnippets?: boolean): CompletionItem[] {
     if (node) {
         // If the value of shouldShowStateSnippets is false prevent the snippets from being displayed
-        if ((isChildOfStates(node) && shouldShowStateSnippets !== false) || shouldShowStateSnippets) {
+        if (shouldShowStateSnippets === undefined ? isChildOfStates(node) : shouldShowStateSnippets) {
             return stateSnippets
         }
 

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -53,13 +53,10 @@ function doesStateSupportErrorHandling(node: ASTNode): boolean {
     return ERROR_HANDLING_STATES.includes(typeNode?.valueNode?.value as string)
 }
 
-export default function completeSnippets(node: ASTNode | undefined, offset: number, forceShowStateSnippets?: boolean): CompletionItem[] {
+export default function completeSnippets(node: ASTNode | undefined, offset: number, shouldShowStateSnippets?: boolean): CompletionItem[] {
     if (node) {
-        // If the value of forceShowStateSnippets is false prevent the snippets from being displayed
-        const shouldShowStateSnippets = (isChildOfStates(node) && forceShowStateSnippets !== false)
-            || forceShowStateSnippets
-
-        if (shouldShowStateSnippets) {
+        // If the value of shouldShowStateSnippets is false prevent the snippets from being displayed
+        if ((isChildOfStates(node) && shouldShowStateSnippets !== false) || shouldShowStateSnippets) {
             return stateSnippets
         }
 

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -193,6 +193,44 @@ States:
 \u0020\u0020
 `
 
+const snippetsCompletionWithinMap = `
+StartAt: Map
+States:
+  Map:
+    Type: Map
+    Next: Final State
+    Iterator:
+      StartAt: Pass
+      States:
+        Pass:
+          Type: Pass
+          Result: Done!
+          End: true
+\u0020\u0020\u0020\u0020\u0020\u0020\u0020\u0020
+  Final State:
+    Type: Pass
+    End: true
+`
+
+const snippetsCompletionWithinParallel = `
+StartAt: Parallel
+States:
+  Parallel:
+    Type: Parallel
+    Next: Final State
+    Branches:
+    - StartAt: Wait 20s
+      States:
+        Wait 20s:
+          Type: Wait
+          Seconds: 20
+          End: true
+\u0020\u0020\u0020\u0020\u0020\u0020\u0020\u0020
+  Final State:
+    Type: Pass
+    End: true
+`
+
 const itemLabels = [
     'FirstState',
     'ChoiceState',
@@ -407,6 +445,7 @@ suite('ASL YAML context-aware completion', () => {
 
           assert.deepEqual(suggestedSnippets, expectedSnippets)
         })
+
         test('Does not show state snippets when cursor placed on first line after States prop with same indentation indendation', async () => {
           const suggestedSnippets = await getSuggestedSnippets({
             json: snippetsCompletionCase2,
@@ -417,6 +456,7 @@ suite('ASL YAML context-aware completion', () => {
 
           assert.deepEqual(suggestedSnippets, [])
         })
+
         test('Shows state snippets when cursor placed on line after state declaration with the indentation same as the previous state name ', async () => {
           const expectedSnippets = stateSnippets.map(item => item.label)
           const suggestedSnippets = await getSuggestedSnippets({
@@ -428,6 +468,7 @@ suite('ASL YAML context-aware completion', () => {
 
           assert.deepEqual(suggestedSnippets, expectedSnippets)
         })
+
         test('Does not show state snippets when cursor placed on line after state declaration with the indentation same as the nested state property name ', async () => {
           const suggestedSnippets = await getSuggestedSnippets({
             json: snippetsCompletionCase1,
@@ -438,6 +479,7 @@ suite('ASL YAML context-aware completion', () => {
 
           assert.deepEqual(suggestedSnippets, [])
         })
+
         test('Shows state snippets when cursor placed 2 lines below last declared state machine with same indentation level as its name', async () => {
           const expectedSnippets = stateSnippets.map(item => item.label)
           const suggestedSnippets = await getSuggestedSnippets({
@@ -445,6 +487,30 @@ suite('ASL YAML context-aware completion', () => {
             position: [14, 2],
             start: [14, 2],
             end: [14, 2]
+          })
+
+          assert.deepEqual(suggestedSnippets, expectedSnippets)
+        })
+
+        test('Shows state snippets when cursor placed within States object of Map state', async () => {
+          const expectedSnippets = stateSnippets.map(item => item.label)
+          const suggestedSnippets = await getSuggestedSnippets({
+            json: snippetsCompletionWithinMap,
+            position: [13, 8],
+            start: [13, 8],
+            end: [13, 8]
+          })
+
+          assert.deepEqual(suggestedSnippets, expectedSnippets)
+        })
+
+        test('Shows state snippets when cursor placed within States object of Parallel state', async () => {
+          const expectedSnippets = stateSnippets.map(item => item.label)
+          const suggestedSnippets = await getSuggestedSnippets({
+            json: snippetsCompletionWithinParallel,
+            position: [13, 8],
+            start: [13, 8],
+            end: [13, 8]
           })
 
           assert.deepEqual(suggestedSnippets, expectedSnippets)

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -11,6 +11,7 @@ export interface ASTTree extends JSONDocument {
 
 export interface ASLOptions {
     ignoreColonOffset?: boolean
+    forceShowStateSnippets?: boolean
 }
 
 export function isStringNode(node: ASTNode): node is StringASTNode {

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -11,7 +11,7 @@ export interface ASTTree extends JSONDocument {
 
 export interface ASLOptions {
     ignoreColonOffset?: boolean
-    forceShowStateSnippets?: boolean
+    shouldShowStateSnippets?: boolean
 }
 
 export function isStringNode(node: ASTNode): node is StringASTNode {


### PR DESCRIPTION
I created alternative way to recognize that the cursor is in the right place to show state snippets. Previously, it was yaml text being put int json ast tree that was casing inaccuracies. Instead, I wrote a function that traverses lines down from the cursor position until it reaches one with lower indentation and that begins with "States:" text. 
