### PR TITLE
Fixes interface for yaml diagnostic

### DIFF
--- a/src/constants/diagnosticStrings.ts
+++ b/src/constants/diagnosticStrings.ts
@@ -13,3 +13,7 @@ export const MESSAGES = {
     INVALID_PROPERTY_NAME: 'Field is not supported.',
     MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.',
 } as const
+
+export const YAML_PARSER_MESSAGES = {
+    DUPLICATE_KEY: 'duplicate key'
+} as const

--- a/src/tests/yamlValidation.test.ts
+++ b/src/tests/yamlValidation.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as assert from 'assert'
-import { MESSAGES } from '../constants/diagnosticStrings'
+import { MESSAGES, YAML_PARSER_MESSAGES } from '../constants/diagnosticStrings'
 import { Diagnostic, DiagnosticSeverity, getYamlLanguageService, Position, Range } from '../service'
 
 import {
@@ -110,7 +110,7 @@ suite('ASL YAML context-aware validation', () => {
         })
 
         test('Shows diagnostic for duplicate key', async () => {
-            const message = 'duplicate key'
+            const message = YAML_PARSER_MESSAGES.DUPLICATE_KEY
 
             await testValidations({
                 json: documentDuplicateKey,

--- a/src/tests/yamlValidation.test.ts
+++ b/src/tests/yamlValidation.test.ts
@@ -14,6 +14,7 @@ import {
     documentChoiceNoDefault,
     documentChoiceValidDefault,
     documentChoiceValidNext,
+    documentDuplicateKey,
     documentInvalidNext,
     documentInvalidNextNested,
     documentInvalidParametersIntrinsicFunction,
@@ -99,13 +100,43 @@ async function testValidations(options: TestValidationOptions) {
 }
 
 suite('ASL YAML context-aware validation', () => {
-    suite('Invalid JSON Input', () => {
+    suite('Invalid YAML Input', () => {
         test("Empty string doesn't throw errors", async () => {
             await assert.doesNotReject(getValidations(''))
         })
 
         test("[] string doesn't throw type errors", async () => {
             await assert.doesNotReject(getValidations('[]'), TypeError)
+        })
+
+        test('Shows diagnostic for duplicate key', async () => {
+            const message = 'duplicate key'
+
+            await testValidations({
+                json: documentDuplicateKey,
+                diagnostics: [
+                    {
+                        message,
+                        start: [3, 2],
+                        end: [3, 9],
+                    },
+                    {
+                        message,
+                        start: [1, 2],
+                        end: [1, 9],
+                    },
+                    {
+                        message,
+                        start: [12, 4],
+                        end: [12, 9],
+                    },
+                    {
+                        message,
+                        start: [9, 4],
+                        end: [9, 9],
+                    },
+                ],
+            })
         })
     })
 

--- a/src/tests/yasl-strings/validationStrings.ts
+++ b/src/tests/yasl-strings/validationStrings.ts
@@ -1098,3 +1098,20 @@ export const documentInvalidResultSelectorIntrinsicFunction = `
     Succeed state:
       Type: Succeed
 `
+
+export const documentDuplicateKey = `
+  StartAt: Hello
+  Comment: A Hello World example of the Amazon States Language using Pass states
+  StartAt: Hello
+  States:
+    Hello:
+      Type: Pass
+      Result: Hello
+      Next: World
+    World:
+      Type: Pass
+      End: true
+    World:
+      Type: Pass
+      End: true
+`

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -7,11 +7,11 @@ import { safeDump, safeLoad } from 'js-yaml'
 import * as prettier from 'prettier'
 import {
     CompletionItemKind,
+    Diagnostic,
     getLanguageService as getLanguageServiceVscode,
     JSONSchema,
     LanguageService,
     LanguageServiceParams,
-    Diagnostic
 } from 'vscode-json-languageservice'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import {
@@ -56,13 +56,13 @@ function convertYAMLDiagnostic(yamlDiagnostic: YAMLDocDiagnostic, textDocument: 
     }
 
     const startPos = textDocument.positionAt(startLoc)
-    let endPos = textDocument.positionAt(endLoc)
-    
+    const endPos = textDocument.positionAt(endLoc)
+
     return {
         range: Range.create(startPos, endPos),
         message: yamlDiagnostic.message,
         severity
-    } 
+    }
 }
 
 export const getLanguageService = function(params: LanguageServiceParams, schema: JSONSchema, aslLanguageService: LanguageService): LanguageService {


### PR DESCRIPTION
*Issue #, if available:*
The diagnostic for yaml structural problems were output in incorrect format. 

*Description of changes:*
I made sure we are matching `Diagnostic` interface for all diagnostics. I also added a fix for `duplicate key` diagnostic. First, it was ending in the wrong place (after to chars) so I update it with the location before first colon+white space char. Second, I overwrite diagnostic as error, not warning. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
