### PR TITLE
Replaces whitespace in YAML snippets with tabs

### DIFF
--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -277,7 +277,7 @@ const stateNameLabels = [
 const nestedItemLabels = ['Nested1', 'Nested2', 'Nested3', 'Nested4']
 
 // tslint:disable-next-line: no-invalid-template-strings
-const passSnippetYaml = '${1:PassState}:\n  Type: Pass\n  Result:\n    data1: 0.5\n    data2: 1.5\n  ResultPath: $.result\n  Next: ${2:NextState}\n'
+const passSnippetYaml = '${1:PassState}:\n\tType: Pass\n\tResult:\n\t\tdata1: 0.5\n\t\tdata2: 1.5\n\tResultPath: $.result\n\tNext: ${2:NextState}\n'
 
 interface TestCompletionOptions {
     labels: string[]

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -35,7 +35,7 @@ import { YAMLDocDiagnostic } from 'yaml-language-server/out/server/src/languages
 import doCompleteAsl from '../completion/completeAsl'
 import { LANGUAGE_IDS } from '../constants/constants'
 import { YAML_PARSER_MESSAGES } from '../constants/diagnosticStrings'
-import { processYamlDocForCompletion } from './yamlUtils'
+import { convertJsonSnippetToYaml, processYamlDocForCompletion } from './yamlUtils'
 
 function convertYAMLDiagnostic(yamlDiagnostic: YAMLDocDiagnostic, textDocument: TextDocument): Diagnostic {
     const startLoc = yamlDiagnostic.location.start
@@ -124,7 +124,7 @@ function isChildOfStates(document: TextDocument, offset: number) {
     })
 
     if (!hasCursorLineNonSpace && numberOfSpacesCursorLine > 0) {
-        for (let lineNum = prevText.length - 2; lineNum > 0; lineNum--) {
+        for (let lineNum = prevText.length - 2; lineNum >= 0; lineNum--) {
             let leftLineSpaces = 0
             const line = prevText[lineNum]
 
@@ -192,9 +192,7 @@ function isChildOfStates(document: TextDocument, offset: number) {
             const completionItemCopy = {...completionItem} // Copy completion to new object to avoid overwriting any snippets
 
             if (completionItemCopy.insertText && completionItemCopy.kind === CompletionItemKind.Snippet && document.languageId === LANGUAGE_IDS.YAML) {
-                completionItemCopy.insertText = safeDump(safeLoad(completionItemCopy.insertText))
-                // Remove quotation marks
-                completionItemCopy.insertText = completionItemCopy.insertText?.replace(/[']/g, '')
+                completionItemCopy.insertText = convertJsonSnippetToYaml(completionItemCopy.insertText)
             } else {
                 const currentTextEdit = completionItemCopy.textEdit
 


### PR DESCRIPTION
*Description of changes:*
I replace all the leading spaces in YAML snippets with tabs. Even though tabs are not valid characters in YAML, they will be automatically converted to appropriate number of spaces in VS Code. This solves the problem of user getting the wrong number of spaces when they settings are different than 2 spaces. 

I also added a fix for snippets not appearing when States property is placed on the first line of the document. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
