### PR TITLE
Bugfix/yaml catch retry snippets

### DIFF
--- a/src/completion/completeAsl.ts
+++ b/src/completion/completeAsl.ts
@@ -33,7 +33,7 @@ export default function completeAsl(document: TextDocument, position: Position, 
 
     const node = findNodeAtLocation(rootNode, offset)
 
-    const snippetsList = completeSnippets(node, offset, aslOptions?.shouldShowStateSnippets)
+    const snippetsList = completeSnippets(node, offset, aslOptions)
     let completionList = completeStateNames(node, offset, document, aslOptions) ?? jsonCompletions
 
     if (completionList?.items) {

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -63,13 +63,10 @@ interface CompleteSnippetsOptions {
 export default function completeSnippets(node: ASTNode | undefined, offset: number, options?: CompleteSnippetsOptions): CompletionItem[] {
     if (node) {
         const errorSnippetOptionsNotDefined = options?.shouldShowErrorSnippets === undefined
-
-        if (options?.shouldShowStateSnippets) {
-            return stateSnippets
-        }
-
         // If the value of shouldShowStateSnippets is false prevent the snippets from being displayed
-        if (options?.shouldShowStateSnippets === undefined && isChildOfStates(node)) {
+        const showStateSnippets = options?.shouldShowStateSnippets || (options?.shouldShowStateSnippets === undefined && isChildOfStates(node))
+
+        if (showStateSnippets) {
             return stateSnippets
         }
 

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -67,8 +67,6 @@ export default function completeSnippets(node: ASTNode | undefined, offset: numb
         }
 
         if (shouldShowErrorSnippets === undefined ? (insideStateNode(node) && doesStateSupportErrorHandling(node)) : shouldShowErrorSnippets) {
-            let snippets = errorHandlingSnippets;
-
             const toShow: string[] = []
 
             if (options?.shouldShowCatchSnippet) {

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -52,16 +52,38 @@ function doesStateSupportErrorHandling(node: ASTNode): boolean {
 
     return ERROR_HANDLING_STATES.includes(typeNode?.valueNode?.value as string)
 }
+interface CompleteSnippetsOptions {
+    shouldShowStateSnippets?: boolean,
+    shouldShowRetrySnippet?: boolean,
+    shouldShowCatchSnippet?: boolean
+}
 
-export default function completeSnippets(node: ASTNode | undefined, offset: number, shouldShowStateSnippets?: boolean): CompletionItem[] {
+export default function completeSnippets(node: ASTNode | undefined, offset: number, options?: CompleteSnippetsOptions): CompletionItem[] {
     if (node) {
+        const shouldShowErrorSnippets = options?.shouldShowCatchSnippet || options?.shouldShowRetrySnippet
         // If the value of shouldShowStateSnippets is false prevent the snippets from being displayed
-        if (shouldShowStateSnippets === undefined ? isChildOfStates(node) : shouldShowStateSnippets) {
+        if (options?.shouldShowStateSnippets === undefined ? isChildOfStates(node) : options.shouldShowStateSnippets) {
             return stateSnippets
         }
 
-        if (insideStateNode(node) && doesStateSupportErrorHandling(node)) {
-            return errorHandlingSnippets
+        if (shouldShowErrorSnippets === undefined ? (insideStateNode(node) && doesStateSupportErrorHandling(node)) : shouldShowErrorSnippets) {
+            let snippets = errorHandlingSnippets;
+
+            const toShow: string[] = []
+
+            if (options?.shouldShowCatchSnippet) {
+                toShow.push('Catch')
+            }
+            
+            if (options?.shouldShowRetrySnippet) {
+                toShow.push('Retry')
+            }
+
+            if (toShow.length) {
+                return errorHandlingSnippets.filter(snippet => toShow.includes(snippet.label))
+            } else {
+                return errorHandlingSnippets
+            }
         }
     }
 

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -72,7 +72,7 @@ export default function completeSnippets(node: ASTNode | undefined, offset: numb
             if (options?.shouldShowCatchSnippet) {
                 toShow.push('Catch')
             }
-            
+
             if (options?.shouldShowRetrySnippet) {
                 toShow.push('Retry')
             }

--- a/src/completion/completeSnippets.ts
+++ b/src/completion/completeSnippets.ts
@@ -55,8 +55,8 @@ function doesStateSupportErrorHandling(node: ASTNode): boolean {
 interface CompleteSnippetsOptions {
     shouldShowStateSnippets?: boolean,
     shouldShowErrorSnippets?: {
-        shouldShowRetrySnippet: boolean,
-        shouldShowCatchSnippet: boolean
+        retry: boolean,
+        catch: boolean
     }
 }
 
@@ -83,11 +83,11 @@ export default function completeSnippets(node: ASTNode | undefined, offset: numb
 
         const errorSnippetsToShow: string[] = []
 
-        if (options?.shouldShowErrorSnippets?.shouldShowCatchSnippet) {
+        if (options?.shouldShowErrorSnippets?.catch) {
             errorSnippetsToShow.push('Catch')
         }
 
-        if (options?.shouldShowErrorSnippets?.shouldShowRetrySnippet) {
+        if (options?.shouldShowErrorSnippets?.retry) {
             errorSnippetsToShow.push('Retry')
         }
 

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -20,7 +20,7 @@ const documentWithStates = `
 StartAt:
 
 States:
-  |
+\u0020\u0020
 `
 
 const document1 = `

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -646,7 +646,7 @@ suite('ASL YAML context-aware completion', () => {
                 assert.deepEqual(suggestedSnippets, [])
             })
 
-            test('Shows state snippets when cursor placed on line after state declaration with the indentation same as the previous state name ', async () => {
+            test('Shows state snippets when cursor placed on line after state declaration with the indentation same as the previous state name', async () => {
                 const expectedSnippets = stateSnippets.map(item => item.label)
                 const suggestedSnippets = await getSuggestedSnippets({
                     yaml: snippetsCompletionCase3,

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -14,8 +14,8 @@ export interface ASLOptions {
     ignoreColonOffset?: boolean
     shouldShowStateSnippets?: boolean
     shouldShowErrorSnippets?: {
-        shouldShowRetrySnippet: boolean
-        shouldShowCatchSnippet: boolean
+        retry: boolean
+        catch: boolean
     }
 }
 

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -13,6 +13,8 @@ export interface ASTTree extends JSONDocument {
 export interface ASLOptions {
     ignoreColonOffset?: boolean
     shouldShowStateSnippets?: boolean
+    shouldShowRetrySnippet?: boolean
+    shouldShowCatchSnippet?: boolean
 }
 
 export interface CompleteStateNameOptions {

--- a/src/utils/astUtilityFunctions.ts
+++ b/src/utils/astUtilityFunctions.ts
@@ -13,8 +13,10 @@ export interface ASTTree extends JSONDocument {
 export interface ASLOptions {
     ignoreColonOffset?: boolean
     shouldShowStateSnippets?: boolean
-    shouldShowRetrySnippet?: boolean
-    shouldShowCatchSnippet?: boolean
+    shouldShowErrorSnippets?: {
+        shouldShowRetrySnippet: boolean
+        shouldShowCatchSnippet: boolean
+    }
 }
 
 export interface CompleteStateNameOptions {

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -35,7 +35,7 @@ import { YAMLDocDiagnostic } from 'yaml-language-server/out/server/src/languages
 import doCompleteAsl from '../completion/completeAsl'
 import { LANGUAGE_IDS } from '../constants/constants'
 import { YAML_PARSER_MESSAGES } from '../constants/diagnosticStrings'
-import { convertJsonSnippetToYaml, processYamlDocForCompletion, getOffsetData } from './yamlUtils'
+import { convertJsonSnippetToYaml, getOffsetData ,processYamlDocForCompletion } from './yamlUtils'
 
 const CATCH_INSERT = 'Catch:\n\t- '
 const RETRY_INSERT = 'Retry:\n\t- '
@@ -109,7 +109,6 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
 
         return validationResult
     }
-
 
     languageService.doComplete = async function(
         document: TextDocument,

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -139,19 +139,19 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
         const yamlCompletions = await completer.doComplete(processedDocument, positionForDoComplete, false)
         // yaml-language-server does not output correct completions for retry/catch
         // we need to overwrite the text
+        function updateCompletionText(item: CompletionItem, text: string) {
+            item.insertText = text
+
+            if (item.textEdit) {
+                item.textEdit.newText = text
+            }
+        }
+
         yamlCompletions.items.forEach(item => {
             if (item.label === 'Catch') {
-                item.insertText = CATCH_INSERT
-
-                if (item.textEdit) {
-                    item.textEdit.newText = CATCH_INSERT
-                }
+                updateCompletionText(item, CATCH_INSERT)
             } else if (item.label === 'Retry') {
-                item.insertText = RETRY_INSERT
-
-                if (item.textEdit) {
-                    item.textEdit.newText = RETRY_INSERT
-                }
+                updateCompletionText(item, RETRY_INSERT)
             }
         })
 
@@ -161,8 +161,8 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
             ignoreColonOffset: true,
             shouldShowStateSnippets: isDirectChildOfStates,
             shouldShowErrorSnippets: {
-                shouldShowRetrySnippet: isWithinCatchRetryState && !hasRetryPropSibling,
-                shouldShowCatchSnippet: isWithinCatchRetryState && !hasCatchPropSibling
+                retry: isWithinCatchRetryState && !hasRetryPropSibling,
+                catch: isWithinCatchRetryState && !hasCatchPropSibling
             }
         }
 

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -35,10 +35,7 @@ import { YAMLDocDiagnostic } from 'yaml-language-server/out/server/src/languages
 import doCompleteAsl from '../completion/completeAsl'
 import { LANGUAGE_IDS } from '../constants/constants'
 import { YAML_PARSER_MESSAGES } from '../constants/diagnosticStrings'
-import { convertJsonSnippetToYaml, processYamlDocForCompletion } from './yamlUtils'
-
-const RETRY_CATCH_STATES = ['Task', 'Map', 'Parallel']
-const RETRY_CATCH_STATES_REGEX_STRING = `(${RETRY_CATCH_STATES.join(')|(')})`
+import { convertJsonSnippetToYaml, processYamlDocForCompletion, getOffsetData } from './yamlUtils'
 
 function convertYAMLDiagnostic(yamlDiagnostic: YAMLDocDiagnostic, textDocument: TextDocument): Diagnostic {
     const startLoc = yamlDiagnostic.location.start
@@ -110,145 +107,6 @@ export const getLanguageService = function(params: LanguageServiceParams, schema
         return validationResult
     }
 
-function getNumberOfLeftSpaces(text: string) {
-    let numOfLeftSpaces = 0
-
-    for (const char of text) {
-        if (char === ' ') {
-            numOfLeftSpaces++
-        } else {
-            break
-        }
-    }
-
-    return numOfLeftSpaces
-}
-
-// Returns true if the given offest is in a position of immediate child of the "States" property. False otherwise.
-function isChildOfStates(document: TextDocument, offset: number) {
-    let isDirectChildOfStates = false
-    let isGrandChildOfStates = false
-    let isWithinCatchRetryState = false;
-    let hasCatchPropSibling = false;
-    let hasRetryPropSibling = false;
-    const prevText = document.getText().substring(0, offset).split('\n')
-    const cursorLine = prevText[prevText.length - 1]
-    let hasCursorLineNonSpace = false
-    let numberOfSpacesCursorLine = 0
-
-    Array.from(cursorLine).forEach(char => {
-        if (char === ' ') {
-            numberOfSpacesCursorLine++
-        } else if (char !== "'" && char !== '"') {
-            hasCursorLineNonSpace = true;
-        }
-    })
-    const initialNumberOfSpaces = numberOfSpacesCursorLine
-    const catchRetryStateRegex = new RegExp(`['"]{0,1}Type['"]{0,1}\\s*:\\s*['"]{0,1}(${RETRY_CATCH_STATES_REGEX_STRING})['"]{0,1}`)
-
-
-    if (!hasCursorLineNonSpace && numberOfSpacesCursorLine > 0) {
-        const text = document.getText()
-        let beginLineOffset = offset;
-        let levelsDown = 0;
-
-        // Iterate the text backwards from the offset
-        for (let i = offset; i >= 0; i--) {
-            if (text[i] === '\n') {
-                const lineText = text.slice(i + 1, beginLineOffset)
-                const numberOfPrecedingSpaces = getNumberOfLeftSpaces(lineText)
-                const trimmedLine = lineText.trim()
-                beginLineOffset = i
-
-                // Ignore empty lines
-                if (trimmedLine.length === 0) {
-                    continue
-                }
-
-                // If number of spaces lower than that of the cursor
-                // it is a parent property or a sibling of parent property
-                if (numberOfPrecedingSpaces < initialNumberOfSpaces) {
-                    if (trimmedLine.startsWith('States:')) {
-                        isDirectChildOfStates = levelsDown === 0;
-                        isGrandChildOfStates = levelsDown === 1;
-                        break
-                    } else if (levelsDown === 0) {
-                        levelsDown++
-                        continue
-                    } else {
-                        break
-                    }
-
-                // If number of spaces is higher than that of the cursor it means it is a child
-                // of the property or of its siblings
-                } else if (numberOfPrecedingSpaces > initialNumberOfSpaces) {
-                    continue
-                } else if (levelsDown > 0) {
-                    continue
-                }
-
-                hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
-                hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
-
-                const isCatchRetryState = catchRetryStateRegex.test(trimmedLine)
-
-                if (isCatchRetryState) {
-                    isWithinCatchRetryState = true
-                    break
-                } else {
-                    continue
-                }
-            }
-        }
-
-        // Reset begin line offset to offset
-        beginLineOffset = offset;
-
-        // Iterate the text forwards from the offset
-        for (let i = offset; i <= text.length; i++) {
-            if (text[i] === '\n') {
-                const lineText = text.slice(beginLineOffset + 1, i)
-                const trimmedLine = lineText.trim()
-                const numberOfPrecedingSpaces = getNumberOfLeftSpaces(lineText)
-                beginLineOffset = i
-
-                // Ignore empty lines
-                if (trimmedLine.length === 0) {
-                    continue
-                }
-
-                // If number of spaces lower than that of the cursor
-                // it is a parent property or a sibling of parent property
-                if (numberOfPrecedingSpaces < initialNumberOfSpaces) {
-                    break
-                // If number of spaces is higher than that of the cursor it means it is a child
-                // of the property or of its siblings
-                } else if (numberOfPrecedingSpaces > initialNumberOfSpaces) {
-                    continue
-                }
-
-                hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
-                hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
-
-                const isCatchRetryState = catchRetryStateRegex.test(trimmedLine)
-
-                if (isCatchRetryState) {
-                    isWithinCatchRetryState = true
-                    break
-                } else {
-                    continue
-                }
-            }
-        }
-    }
-
-    return {
-        isDirectChildOfStates,
-        isWithinCatchRetryState,
-        hasCatchPropSibling,
-        hasRetryPropSibling
-    }
-}
 
     languageService.doComplete = async function(
         document: TextDocument,
@@ -276,7 +134,7 @@ function isChildOfStates(document: TextDocument, offset: number) {
 
         const positionForDoComplete = {...tempPositionForCompletions} // Copy position to new object since doComplete modifies the position
         const yamlCompletions = await completer.doComplete(processedDocument, positionForDoComplete, false)
-        const { isDirectChildOfStates, isWithinCatchRetryState, hasCatchPropSibling, hasRetryPropSibling } = isChildOfStates(document, offsetIntoOriginalDocument)
+        const { isDirectChildOfStates, isWithinCatchRetryState, hasCatchPropSibling, hasRetryPropSibling } = getOffsetData(document, offsetIntoOriginalDocument)
 
         const aslOptions = {
             ignoreColonOffset: true,

--- a/src/yaml/yamlUtils.ts
+++ b/src/yaml/yamlUtils.ts
@@ -308,3 +308,146 @@ export function convertJsonSnippetToYaml(snippetText: string) {
         })
         .join('\n')
 }
+
+
+function getNumberOfLeftSpaces(text: string) {
+    let numOfLeftSpaces = 0
+
+    for (const char of text) {
+        if (char === ' ') {
+            numOfLeftSpaces++
+        } else {
+            break
+        }
+    }
+
+    return numOfLeftSpaces
+}
+
+const RETRY_CATCH_STATES = ['Task', 'Map', 'Parallel']
+const RETRY_CATCH_STATES_REGEX_STRING = `(${RETRY_CATCH_STATES.join(')|(')})`
+const CATCH_RETRY_STATE_REGEX = new RegExp(`['"]{0,1}Type['"]{0,1}\\s*:\\s*['"]{0,1}(${RETRY_CATCH_STATES_REGEX_STRING})['"]{0,1}`)
+
+// Returns true if the given offest is in a position of immediate child of the "States" property. False otherwise.
+export function getOffsetData(document: TextDocument, offset: number) {
+    let isDirectChildOfStates = false
+    let isGrandChildOfStates = false
+    let isWithinCatchRetryState = false;
+    let hasCatchPropSibling = false;
+    let hasRetryPropSibling = false;
+    const prevText = document.getText().substring(0, offset).split('\n')
+    const cursorLine = prevText[prevText.length - 1]
+    let hasCursorLineNonSpace = false
+    let numberOfSpacesCursorLine = 0
+
+    Array.from(cursorLine).forEach(char => {
+        if (char === ' ') {
+            numberOfSpacesCursorLine++
+        } else if (char !== "'" && char !== '"') {
+            hasCursorLineNonSpace = true;
+        }
+    })
+    const initialNumberOfSpaces = numberOfSpacesCursorLine
+
+    if (!hasCursorLineNonSpace && numberOfSpacesCursorLine > 0) {
+        const text = document.getText()
+        let beginLineOffset = offset;
+        let levelsDown = 0;
+
+        // Iterate the text backwards from the offset
+        for (let i = offset; i >= 0; i--) {
+            if (text[i] === '\n') {
+                const lineText = text.slice(i + 1, beginLineOffset)
+                const numberOfPrecedingSpaces = getNumberOfLeftSpaces(lineText)
+                const trimmedLine = lineText.trim()
+                beginLineOffset = i
+
+                // Ignore empty lines
+                if (trimmedLine.length === 0) {
+                    continue
+                }
+
+                // If number of spaces lower than that of the cursor
+                // it is a parent property or a sibling of parent property
+                if (numberOfPrecedingSpaces < initialNumberOfSpaces) {
+                    if (trimmedLine.startsWith('States:')) {
+                        isDirectChildOfStates = levelsDown === 0;
+                        isGrandChildOfStates = levelsDown === 1;
+                        break
+                    } else if (levelsDown === 0) {
+                        levelsDown++
+                        continue
+                    } else {
+                        break
+                    }
+
+                // If number of spaces is higher than that of the cursor it means it is a child
+                // of the property or of its siblings
+                } else if (numberOfPrecedingSpaces > initialNumberOfSpaces) {
+                    continue
+                } else if (levelsDown > 0) {
+                    continue
+                }
+
+                hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
+                hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
+
+                const isCatchRetryState = CATCH_RETRY_STATE_REGEX.test(trimmedLine)
+
+                if (isCatchRetryState) {
+                    isWithinCatchRetryState = true
+                    break
+                } else {
+                    continue
+                }
+            }
+        }
+
+        // Reset begin line offset to offset
+        beginLineOffset = offset;
+
+        // Iterate the text forwards from the offset
+        for (let i = offset; i <= text.length; i++) {
+            if (text[i] === '\n') {
+                const lineText = text.slice(beginLineOffset + 1, i)
+                const trimmedLine = lineText.trim()
+                const numberOfPrecedingSpaces = getNumberOfLeftSpaces(lineText)
+                beginLineOffset = i
+
+                // Ignore empty lines
+                if (trimmedLine.length === 0) {
+                    continue
+                }
+
+                // If number of spaces lower than that of the cursor
+                // it is a parent property or a sibling of parent property
+                if (numberOfPrecedingSpaces < initialNumberOfSpaces) {
+                    break
+                // If number of spaces is higher than that of the cursor it means it is a child
+                // of the property or of its siblings
+                } else if (numberOfPrecedingSpaces > initialNumberOfSpaces) {
+                    continue
+                }
+
+                hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
+                hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
+
+                const isCatchRetryState = CATCH_RETRY_STATE_REGEX.test(trimmedLine)
+
+                if (isCatchRetryState) {
+                    isWithinCatchRetryState = true
+                    break
+                } else {
+                    continue
+                }
+            }
+        }
+    }
+
+    return {
+        isDirectChildOfStates,
+        isWithinCatchRetryState,
+        hasCatchPropSibling,
+        hasRetryPropSibling
+    }
+}

--- a/src/yaml/yamlUtils.ts
+++ b/src/yaml/yamlUtils.ts
@@ -11,6 +11,9 @@ const YAML_RESERVED_KEYWORDS = ['y', 'yes', 'n', 'no', 'true', 'false', 'on', 'o
 const RETRY_CATCH_STATES = ['Task', 'Map', 'Parallel']
 const RETRY_CATCH_STATES_REGEX_STRING = `(${RETRY_CATCH_STATES.join(')|(')})`
 const CATCH_RETRY_STATE_REGEX = new RegExp(`['"]{0,1}Type['"]{0,1}\\s*:\\s*['"]{0,1}(${RETRY_CATCH_STATES_REGEX_STRING})['"]{0,1}`)
+const STATES_PROP_STRING = 'States:'
+const CATCH_PROP_STRING = 'Catch:'
+const RETRY_PROP_STRING = 'Retry:'
 
 /**
  * @typedef {Object} ProcessYamlDocForCompletionOutput
@@ -340,13 +343,17 @@ function getBackwardOffsetData(text: string, offset: number, initialNumberOfSpac
             // If number of spaces lower than that of the cursor
             // it is a parent property or a sibling of parent property
             if (numberOfPrecedingSpaces < initialNumberOfSpaces) {
-                if (trimmedLine.startsWith('States:')) {
+                if (trimmedLine.startsWith(STATES_PROP_STRING)) {
                     isDirectChildOfStates = levelsDown === 0;
                     isGrandChildOfStates = levelsDown === 1;
                     break
+                // If the indentation is one level lower increase the number in levelsDown variable
+                // and start checking if the offset is a "grandchild" of states.
                 } else if (levelsDown === 0) {
                     levelsDown++
                     continue
+                // When the levelDown is 1 it means there is no point of searching anymore.
+                // We know that the offset is neither child nor grandchild of states. We have all the needed information.
                 } else {
                     break
                 }
@@ -359,8 +366,8 @@ function getBackwardOffsetData(text: string, offset: number, initialNumberOfSpac
                 continue
             }
 
-            hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
-            hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
+            hasCatchPropSibling = trimmedLine.startsWith(CATCH_PROP_STRING) || hasCatchPropSibling
+            hasRetryPropSibling = trimmedLine.startsWith(RETRY_PROP_STRING) || hasRetryPropSibling
 
             const isCatchRetryState = CATCH_RETRY_STATE_REGEX.test(trimmedLine)
 
@@ -408,8 +415,8 @@ function getForwardOffsetData(text: string, offset: number, initialNumberOfSpace
                 continue
             }
 
-            hasCatchPropSibling = trimmedLine.startsWith('Catch:') || hasCatchPropSibling
-            hasRetryPropSibling = trimmedLine.startsWith('Retry:') || hasRetryPropSibling
+            hasCatchPropSibling = trimmedLine.startsWith(CATCH_PROP_STRING) || hasCatchPropSibling
+            hasRetryPropSibling = trimmedLine.startsWith(RETRY_PROP_STRING) || hasRetryPropSibling
 
             const isCatchRetryState = CATCH_RETRY_STATE_REGEX.test(trimmedLine)
 

--- a/src/yaml/yamlUtils.ts
+++ b/src/yaml/yamlUtils.ts
@@ -309,7 +309,6 @@ export function convertJsonSnippetToYaml(snippetText: string) {
         .join('\n')
 }
 
-
 function getNumberOfLeftSpaces(text: string) {
     let numOfLeftSpaces = 0
 
@@ -328,6 +327,7 @@ const RETRY_CATCH_STATES = ['Task', 'Map', 'Parallel']
 const RETRY_CATCH_STATES_REGEX_STRING = `(${RETRY_CATCH_STATES.join(')|(')})`
 const CATCH_RETRY_STATE_REGEX = new RegExp(`['"]{0,1}Type['"]{0,1}\\s*:\\s*['"]{0,1}(${RETRY_CATCH_STATES_REGEX_STRING})['"]{0,1}`)
 
+// tslint:disable:cyclomatic-complexity
 // Returns true if the given offest is in a position of immediate child of the "States" property. False otherwise.
 export function getOffsetData(document: TextDocument, offset: number) {
     let isDirectChildOfStates = false


### PR DESCRIPTION
*Description of changes:*
Custom completion functionality to add catch/retry snippets to yaml. I also overwrite the text of catch/retry completions coming from json schema as they were incorrect. 

I updated the functionality for state snippets to make it more performant and use it for both states and catch/retry. Instead of converting the asl string to an array based on new lines I iterate the string backward and forward to obtain the necessary data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
