### PR TITLE
Removes dependency on prettier and fixes format function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,11 +50,6 @@
 			"integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
 			"dev": true
 		},
-		"@types/prettier": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
-			"integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ=="
-		},
 		"agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -863,11 +858,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
 			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
 			"dev": true
-		},
-		"prettier": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
 		},
 		"readdirp": {
 			"version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -37,23 +37,11 @@
 		"typescript": "^3.7.5"
 	},
 	"dependencies": {
-		"@types/prettier": "^2.1.1",
 		"js-yaml": "^3.14.0",
-		"prettier": "^1.19.1",
 		"vscode-json-languageservice": "3.4.9",
 		"vscode-languageserver": "^6.1.1",
 		"vscode-languageserver-textdocument": "^1.0.0",
 		"vscode-languageserver-types": "^3.15.1",
 		"yaml-language-server": "0.10.0"
-	},
-	"prettier": {
-		"printWidth": 120,
-		"trailingComma": "es5",
-		"tabWidth": 4,
-		"singleQuote": true,
-		"semi": false,
-		"bracketSpacing": true,
-		"arrowParens": "avoid",
-		"endOfLine": "lf"
 	}
 }

--- a/src/yaml/aslYamlLanguageService.ts
+++ b/src/yaml/aslYamlLanguageService.ts
@@ -4,7 +4,6 @@
  */
 
 import { safeDump, safeLoad } from 'js-yaml'
-import * as prettier from 'prettier'
 import {
     CompletionItemKind,
     Diagnostic,
@@ -18,6 +17,7 @@ import {
     CompletionItem,
     CompletionList,
     DocumentSymbol,
+    FormattingOptions,
     Hover,
     Position,
     Range,
@@ -249,12 +249,13 @@ function isChildOfStates(document: TextDocument, offset: number) {
     }
 
     languageService.format = function(
-        document: TextDocument
+        document: TextDocument,
+        range: Range,
+        options: FormattingOptions
     ): TextEdit[] {
         try {
             const text = document.getText()
-
-            const formatted = prettier.format(text, { parser: 'yaml' })
+            const formatted = safeDump(safeLoad(text), { indent: options.tabSize })
 
             return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)]
         } catch (error) {


### PR DESCRIPTION
The dependency on `prettier` was adding almost 7Mb to bundle size and formatting function didn't work as expected. I removed `prettier` and used `js-yaml` to do formatting. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
