### PR TITLE
chore: configure dependabot to run weekly

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+# Reference: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "pr/dependabot"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
dependabot will run every week to update dependencies in our repository.

It will pick up the package manifest (`package.json`) and update all dependencies that have updates available. 

This automates the npm update flow and ensures that our dependencies are fresh

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
