### PR TITLE
Add code snippet for EventBridge Task State

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "1.6.4",
+	"version": "1.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "1.6.4",
+	"version": "1.7.0",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"

--- a/src/json-schema/bundled.json
+++ b/src/json-schema/bundled.json
@@ -251,6 +251,8 @@
 											"arn:aws:states:::elasticmapreduce:setClusterTerminationProtection",
 											"arn:aws:states:::elasticmapreduce:terminateCluster",
 											"arn:aws:states:::elasticmapreduce:terminateCluster.sync",
+											"arn:aws:states:::events:putEvents",
+											"arn:aws:states:::events:putEvents.waitForTaskToken",
 											"arn:aws:states:::glue:startJobRun",
 											"arn:aws:states:::glue:startJobRun.sync",
 											"arn:aws:states:::lambda:invoke",

--- a/src/json-schema/partial/task_state.json
+++ b/src/json-schema/partial/task_state.json
@@ -42,6 +42,8 @@
                                 "arn:aws:states:::elasticmapreduce:setClusterTerminationProtection",
                                 "arn:aws:states:::elasticmapreduce:terminateCluster",
                                 "arn:aws:states:::elasticmapreduce:terminateCluster.sync",
+                                "arn:aws:states:::events:putEvents",
+                                "arn:aws:states:::events:putEvents.waitForTaskToken",
                                 "arn:aws:states:::glue:startJobRun",
                                 "arn:aws:states:::glue:startJobRun.sync",
                                 "arn:aws:states:::lambda:invoke",

--- a/src/snippets/states.json
+++ b/src/snippets/states.json
@@ -52,7 +52,7 @@
             "\t\"Next\": \"${2:NextState}\"",
             "}"
         ],
-        "description": "Code snippet for an EventBridge Task state.\n\nCalls the Amazon EventBridge PutEvents API to send a custom event to an eventbus."
+        "description": "Code snippet for an EventBridge Task state.\n\nCalls the Amazon EventBridge PutEvents API to send a custom event to an event bus."
 	},
 	{
         "name": "SNS Task State",

--- a/src/snippets/states.json
+++ b/src/snippets/states.json
@@ -32,6 +32,29 @@
         "description": "Code snippet for a Lambda Task state.\n\nCalls the AWS Lambda Invoke API to invoke a function."
 	},
 	{
+        "name": "EventBridge Task State",
+        "body": [
+            "\"${1:Send an EventBridge custom event}\": {",
+            "\t\"Type\": \"Task\",",
+            "\t\"Resource\": \"arn:aws:states:::events:putEvents\",",
+            "\t\"Parameters\": {",
+            "\t\t\"Entries\": [",
+            "\t\t\t{",
+            "\t\t\t\t\"Detail\": {",
+            "\t\t\t\t\t\"Message\": \"${4:Hello from Step Functions!}\"",
+            "\t\t\t\t},",
+            "\t\t\t\t\"DetailType\": \"${5:MyDetailType}\",",
+            "\t\t\t\t\"EventBusName\": \"${6:MyEventBusName}\",",
+            "\t\t\t\t\"Source\": \"${7:MySource}\"",
+            "\t\t\t}",
+            "\t\t]",
+            "\t},",
+            "\t\"Next\": \"${2:NextState}\"",
+            "}"
+        ],
+        "description": "Code snippet for an EventBridge Task state.\n\nCalls the Amazon EventBridge PutEvents API to send a custom event to an eventbus."
+	},
+	{
         "name": "SNS Task State",
         "body": [
             "\"${1:Send message to SNS}\": {",

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -305,6 +305,7 @@ const topLevelLabels = [
 const stateSnippetLabels = [
     'Pass State',
     'Lambda Task State',
+    'EventBridge Task State',
     'SNS Task State',
     'Batch Task State',
     'ECS Task State',


### PR DESCRIPTION
Pull Request to add new code snippet for EventBridge Put Events API.

*Description of changes:*
Added a Code Snippet for EventBridge Put Events Task State 
https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/building-stepfunctions.html#building-stepfunctions-code-snippets

*Testing:*
Modified package locally and tested using VS Code Support to see if user could create an EventBridge Task state and visualize it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
