### PR TITLE
Add maximum to MaxAttempt property in JSON Schema

### DIFF
--- a/src/json-schema/bundled.json
+++ b/src/json-schema/bundled.json
@@ -316,12 +316,13 @@
 												},
 												"IntervalSeconds": {
 													"$ref": "#/properties/TimeoutSeconds",
-													"description": "A positive integer representing the number of seconds before the first retry attempt. (Default: 1)"
+													"description": "A positive integer representing the number of seconds before the first retry attempt. (Default: 1, Maximum: 99999999)"
 												},
 												"MaxAttempts": {
 													"type": "integer",
-													"description": "A non-negative integer representing the maximum number of retry attempts. (Default: 3)",
-													"minimum": 0
+													"description": "A non-negative integer representing the maximum number of retry attempts. (Default: 3, Maximum: 99999999)",
+													"minimum": 0,
+													"maximum": 99999999
 												},
 												"BackoffRate": {
 													"type": "number",

--- a/src/json-schema/partial/common.json
+++ b/src/json-schema/partial/common.json
@@ -152,12 +152,13 @@
                     },
                     "IntervalSeconds": {
                         "$ref": "#/definitions/seconds",
-                        "description": "A positive integer representing the number of seconds before the first retry attempt. (Default: 1)"
+                        "description": "A positive integer representing the number of seconds before the first retry attempt. (Default: 1, Maximum: 99999999)"
                     },
                     "MaxAttempts": {
                         "type": "integer",
-                        "description": "A non-negative integer representing the maximum number of retry attempts. (Default: 3)",
-                        "minimum": 0
+                        "description": "A non-negative integer representing the maximum number of retry attempts. (Default: 3, Maximum: 99999999)",
+                        "minimum": 0,
+                        "maximum": 99999999
                     },
                     "BackoffRate": {
                         "type": "number",


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
I added maximum value of 99999999 to JSON Schema to "MaxAttempts" property of "Retry"
<img width="879" alt="Screen Shot 2021-05-21 at 5 48 57 PM" src="https://user-images.githubusercontent.com/6964729/119209805-afdaa980-ba5d-11eb-9061-3d8852afe7eb.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
