### PR TITLE
fix: add missing Credentials field to Task

### DIFF
--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -933,7 +933,10 @@ export const documentInvalidPropertiesState = `{
           "Resource": "arn:aws:lambda:us-east-1:111111111111:function:FUNCTION_NAME",
           "Next": "ChoiceState",
           "SomethingInvalid1": "dddd",
-          "SomethingInvalid2": "eeee"
+          "SomethingInvalid2": "eeee",
+          "Credentials": {
+              "RoleArn": "arn:aws:iam::111122223333:role/LambdaRole"
+          }
       },
       "ChoiceState": {
           "Type": "Choice",

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -25,6 +25,7 @@ export default {
             Properties: {
                 Resource: true,
                 Parameters: true,
+                Credentials: true,
                 ResultSelector: true,
                 ResultPath: true,
                 TimeoutSeconds: true,


### PR DESCRIPTION
The Task state schema definition is missing the optional Credentials field causing valid asl forms to fail validation.

https://github.com/aws/aws-toolkit-vscode/issues/3152

*Description of changes:*
Add "Credentials" to the list of valid Task state fields.

`Credentials` is defined as a valid parameter by both:

https://states-language.net/#task-state
> A Task State MAY include a "Credentials" field, whose value MUST be a JSON object whose value is defined by the interpreter. The States language does not constrain the value of the "Credentials" field. The interpreter will use the specified credentials to execute the work identified by the state's "Resource" field.

and
https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-task-state.html#task-state-fields

> Credentials (Optional)
>
>    Specifies a target role the state machine's execution role must assume before invoking the specified Resource. Alternatively, you can also specify a JSONPath value that resolves to an IAM role ARN at runtime based on the execution input. If you specify a JSONPath value, you must prefix it with the $. notation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
