### PR TITLE
Adds contextual validation for states nested in DistributedMap

### DIFF
--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -3,6 +3,35 @@
  * SPDX-License-Identifier: MIT
  */
 
+export const documentDistributedMapInvalidNextInNestedState = `
+{
+  "StartAt": "Map",
+  "States": {
+      "Map": {
+          "Type": "Map",
+          "ItemsPath": "$.array",
+          "ResultPath": "$.array",
+          "MaxConcurrency": 2,
+          "Next": "Final State",
+          "ItemProcessor": {
+              "StartAt": "Pass",
+              "States": {
+                  "Pass": {
+                      "Type": "Pass",
+                      "Result": "Done!",
+                      "Next": "StateThatDoesNotExist"
+                  }
+              }
+          }
+      },
+      "Final State": {
+          "Type": "Pass",
+          "End": true
+      }
+  }
+}
+`
+
 export const documentStartAtInvalid = `{
   "StartAt": "First",
   "States": {

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -16,6 +16,7 @@ import {
     documentChoiceNoDefault,
     documentChoiceValidDefault,
     documentChoiceValidNext,
+    documentDistributedMapInvalidNextInNestedState,
     documentInvalidNext,
     documentInvalidNextNested,
     documentInvalidParametersIntrinsicFunction,
@@ -422,6 +423,24 @@ suite('ASL context-aware validation', () => {
                     },
                 ],
                 filterMessages: [MESSAGES.UNREACHABLE_STATE]
+            })
+        })
+
+        test('Shows diagnostics on invalid next property of a nested state withing DistributedMap', async () => {
+            await testValidations({
+                json: documentDistributedMapInvalidNextInNestedState,
+                diagnostics: [
+                    {
+                        message: MESSAGES.INVALID_NEXT,
+                        start: [16, 30],
+                        end: [16, 53],
+                    },
+                    {
+                        message: MESSAGES.NO_TERMINAL_STATE,
+                        start: [12, 14],
+                        end: [12, 22],
+                    },
+                ],
             })
         })
     })

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -210,7 +210,7 @@ export default function validateStates(rootNode: ObjectASTNode, document: TextDo
                     switch(stateType) {
                         // if the type of the state is "Map" recursively run validateStates for its value node
                         case 'Map': {
-                            const iteratorPropNode = findPropChildByName(oneStateValueNode, 'Iterator')
+                            const iteratorPropNode = findPropChildByName(oneStateValueNode, 'Iterator') || findPropChildByName(oneStateValueNode, 'ItemProcessor')
 
                             if (iteratorPropNode && iteratorPropNode.valueNode && isObjectNode(iteratorPropNode.valueNode)) {
                                 // append the result of recursive validation to the list of diagnostics


### PR DESCRIPTION
The recursive validation function only validated states nested within `Iterator` property but not within new `ItemProcessor` property of Map state. 

I've added `ItemProcessor` to the function and relevant test. 