### PR TITLE
fix: allow newline in Intrinsic Function args

### DIFF
--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -1198,7 +1198,8 @@ export const documentValidParametersIntrinsicFunction = `
           "Input3.$": "States.StringToJson($.escaped)",
           "Input4.$": "States.Format($.template, $.firstName, $.lastName)    ",
           "Input5.$": "States.JsonToString($)    ",
-          "Input6.$": "States.StringToJson($.escaped)    "
+          "Input6.$": "States.StringToJson($.escaped)    ",
+          "Input7.$": "States.Format('one {}\\ntwo {}', $.firstName, 'literal')"
         }
       },
       "Next": "Succeed state"
@@ -1225,7 +1226,8 @@ export const documentInvalidParametersIntrinsicFunction = `
           "Input3.$": "States.StringToJson $.escaped)",
           "Input4.$": "States. ",
           "Input5.$": "JsonToString($)",
-          "Input6.$": "something else    "
+          "Input6.$": "something else    ",
+          "Input7.$": "States\\nJsonToString($)"
         }
       },
       "Next": "Succeed state"

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -665,6 +665,11 @@ suite('ASL context-aware validation', () => {
                         start: [15, 22],
                         end: [15, 42]
                     },
+                    {
+                        message: MESSAGES.INVALID_JSON_PATH_OR_INTRINSIC,
+                        start: [16, 22],
+                        end: [16, 47]
+                    },
                 ]
             })
         })

--- a/src/validation/validateStates.ts
+++ b/src/validation/validateStates.ts
@@ -27,7 +27,7 @@ import getPropertyNodeDiagnostic from './utils/getPropertyNodeDiagnostic'
 import validateProperties from './validateProperties'
 import schema from './validationSchema'
 
-const INTRINSIC_FUNC_REGEX = /^States\.(?:(JsonToString|Format|StringToJson|Array|ArrayContains|ArrayGetItem|ArrayLength|ArrayPartition|ArrayRange|ArrayUnique|Base64Decode|Base64Encode|Hash|JsonMerge|MathAdd|MathRandom|StringSplit)\(.+\)|(UUID)\(\))$/
+const INTRINSIC_FUNC_REGEX = /^States\.(?:(JsonToString|Format|StringToJson|Array|ArrayContains|ArrayGetItem|ArrayLength|ArrayPartition|ArrayRange|ArrayUnique|Base64Decode|Base64Encode|Hash|JsonMerge|MathAdd|MathRandom|StringSplit)\(.+\)|(UUID)\(\))$/s
 
 function stateNameExistsInPropNode(
     nextPropNode: PropertyASTNode,


### PR DESCRIPTION
Fixes #95.

- Amend the regex parsing Intrinsic Function inputs to run in /s (aka DOTALL) mode.
  - This allows newlines (`\n`) passed inside arguments to Intrinsic Functions to pass validation without raising diagnostics.
- Add unit test to cover success case for input containing `\n`
- Add unit test covering failure case where `\n`  out of position. This also verifies that `States.` parses the terminating `.` literally rather than as a control character.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
