### PR TITLE
Add support for missing ItemProcessor properties

### DIFF
--- a/src/constants/diagnosticStrings.ts
+++ b/src/constants/diagnosticStrings.ts
@@ -11,7 +11,7 @@ export const MESSAGES = {
     UNREACHABLE_STATE: 'The state cannot be reached. It must be referenced by at least one other state.',
     NO_TERMINAL_STATE: 'No terminal state. The state machine must have at least one terminal state (a state in which the "End" property is set to true).',
     INVALID_PROPERTY_NAME: 'Field is not supported.',
-    MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.',
+    MUTUALLY_EXCLUSIVE_CHOICE_PROPERTIES: 'Each Choice Rule can only have one comparison operator.'
 } as const
 
 export const YAML_PARSER_MESSAGES = {

--- a/src/json-schema/bundled.json
+++ b/src/json-schema/bundled.json
@@ -2440,8 +2440,20 @@
 														]
 													}
 												}
+											},
+											"StartAt": {
+												"type": "string",
+												"description": "A string that must exactly match (is case sensitive) the name of one of the state objects.",
+												"minLength": 1
+											},
+											"States": {
+												"$ref": "#/properties/States"
 											}
-										}
+										},
+										"required": [
+											"StartAt",
+											"States"
+										]
 									},
 									"Label": {
 										"type": "string",

--- a/src/json-schema/partial/map_state.json
+++ b/src/json-schema/partial/map_state.json
@@ -218,8 +218,20 @@
                                             ]
                                         }
                                     }
-                                }    
-                            }
+                                },
+                                "StartAt": {
+                                    "type": "string",
+                                    "description": "A string that must exactly match (is case sensitive) the name of one of the state objects.",
+                                    "minLength": 1
+                                },
+                                "States": {
+                                    "$ref": "states.json#/definitions/states"
+                                } 
+                            },
+                            "required": [
+                                "StartAt",
+                                "States"
+                            ]
                         },
                         "Label": {
                             "type": "string",

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,7 +22,7 @@ import {
 
 import completeAsl from './completion/completeAsl'
 import { LANGUAGE_IDS } from './constants/constants';
-import validateStates from './validation/validateStates'
+import validateStates, { RootType } from './validation/validateStates'
 import { getLanguageService as getAslYamlLanguageService } from './yaml/aslYamlLanguageService'
 
 export * from 'vscode-json-languageservice'
@@ -66,7 +66,7 @@ export const getLanguageService = function( params: ASLLanguageServiceParams): L
         const rootNode = (jsonDocument as ASTTree).root
 
         if (rootNode && isObjectNode(rootNode)) {
-            const aslDiagnostics = validateStates(rootNode, document, true, params.aslOptions)
+            const aslDiagnostics = validateStates(rootNode, document, RootType.Root, params.aslOptions)
 
             return diagnostics.concat(aslDiagnostics)
         }

--- a/src/tests/json-strings/validationStrings.ts
+++ b/src/tests/json-strings/validationStrings.ts
@@ -1683,3 +1683,59 @@ export const documentInvalidResultSelectorIntrinsicFunction = `
   }
 }
 `
+export const documentMapProcessorConfig = `
+{
+  "StartAt": "Map",
+  "States": {
+      "Map": {
+          "Type": "Map",
+          "ItemsPath": "$.array",
+          "ResultPath": "$.array",
+          "MaxConcurrency": 2,
+          "Next": "Final State",
+          "ItemProcessor": {
+              "StartAt": "Pass",
+              "States": {
+                  "Pass": {
+                      "Type": "Pass",
+                      "End": true
+                  }
+              },
+              "ProcessorConfig": {
+                "ExecutionType": "EXPRESS",
+                "Mode": "DISTRIBUTED"
+              }
+          }
+      },
+      "Final State": {
+          "Type": "Pass",
+          "End": true
+      }
+  }
+}
+`
+
+export const documentMapInvalidItemProcessorConfig = `
+{
+  "StartAt": "Map",
+  "States": {
+      "Map": {
+          "Type": "Map",
+          "ItemsPath": "$.array",
+          "ResultPath": "$.array",
+          "MaxConcurrency": 2,
+          "Next": "Final State",
+          "ItemProcessor": {
+              "ProcessorConfig": {
+                "ExecutionType": "EXPRESS",
+                "Mode": "DISTRIBUTED"
+              }
+          }
+      },
+      "Final State": {
+          "Type": "Pass",
+          "End": true
+      }
+  }
+}
+`

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -30,6 +30,8 @@ import {
     documentInvalidResultSelectorJsonPath,
     documentMapCatchTemplate,
     documentMapCatchTemplateInvalidNext,
+    documentMapInvalidItemProcessorConfig,
+    documentMapProcessorConfig,
     documentNestedNoTerminalState,
     documentNestedUnreachableState,
     documentNoTerminalState,
@@ -197,6 +199,33 @@ suite('ASL context-aware validation', () => {
                 filterMessages: [MESSAGES.UNREACHABLE_STATE, MESSAGES.NO_TERMINAL_STATE]
             })
         })
+    })
+
+    suite('Map State', () => {
+
+        test('Doesn\'t show diagnostics for valid processor config', async () => {
+            await testValidations({
+                json: documentMapProcessorConfig,
+                diagnostics: []
+            })
+        })
+
+        test('Shows diagnostics on ItemProcessor that does not have required states', async () => {
+            await testValidations({
+                json: documentMapInvalidItemProcessorConfig,
+                diagnostics: [  {
+                    message: 'Missing property "StartAt".',
+                    start: [10, 10],
+                    end: [10, 25]
+                },
+                {
+                    message: 'Missing property "States".',
+                    start: [10, 10],
+                    end: [10, 25]
+                },]
+            })
+        })
+
     })
 
     suite('Next', () => {

--- a/src/validation/validationSchema.ts
+++ b/src/validation/validationSchema.ts
@@ -206,9 +206,15 @@ export default {
         States: true
     },
     // State machines nested within Map and Parallel states
-    NestedRoot: {
+    NestedParallelRoot: {
         Comment: true,
         StartAt: true,
         States: true
+    },
+    NestedMapRoot: {
+        Comment: true,
+        StartAt: true,
+        States: true,
+        ProcessorConfig: true
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Related to [102](https://github.com/aws/amazon-states-language-service/issues/102)

*Description of changes:*

This PR adds missing **ProcessorConfig** property in ItemProcessor. It also updates the ASL schema for ItemProcessor to make **States** and **StartAt** a required property.

*Testing:*

-  Unit testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
