### PR TITLE
Release v1.10

### DIFF
--- a/.github/workflows/compile-lint-test.yml
+++ b/.github/workflows/compile-lint-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "amazon-states-language-service",
-			"version": "1.9.0",
+			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"


### PR DESCRIPTION
- Pin CI Nodejs version to 16 rather than 18. This is to ensure that our CI happens on the same version as the most common client for this service, VS Code, uses Nodejs 16 via Electron.
- Minor version release bump.

This release contains:
- Closes #92 “asl format doesn't allow Credentials key”
- Closes #102 “Does the ASL editor not support ProcessorConfig property”
- Closes #101 “Support for comments in YAML State Machines”


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
