### PR TITLE
Add code snippet for MediaConvert Task State

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "amazon-states-language-service",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "amazon-states-language-service",
-			"version": "1.11.0",
+			"version": "1.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.1.0",
@@ -304,9 +304,9 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -1115,9 +1115,9 @@
 			]
 		},
 		"node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -1903,9 +1903,9 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -2503,9 +2503,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true
 		},
 		"serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/aws/amazon-states-language-service"
 	},
 	"license": "MIT",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"publisher": "aws",
 	"categories": [
 		"Programming Languages"

--- a/src/json-schema/bundled.json
+++ b/src/json-schema/bundled.json
@@ -274,6 +274,8 @@
 											"arn:aws:states:::glue:startJobRun.sync",
 											"arn:aws:states:::lambda:invoke",
 											"arn:aws:states:::lambda:invoke.waitForTaskToken",
+											"arn:aws:states:::mediaconvert:createJob",
+											"arn:aws:states:::mediaconvert:createJob.sync",
 											"arn:aws:states:::sagemaker:createEndpoint",
 											"arn:aws:states:::sagemaker:createEndpointConfig",
 											"arn:aws:states:::sagemaker:createHyperParameterTuningJob",

--- a/src/json-schema/partial/task_state.json
+++ b/src/json-schema/partial/task_state.json
@@ -48,6 +48,8 @@
                                 "arn:aws:states:::glue:startJobRun.sync",
                                 "arn:aws:states:::lambda:invoke",
                                 "arn:aws:states:::lambda:invoke.waitForTaskToken",
+                                "arn:aws:states:::mediaconvert:createJob",
+                                "arn:aws:states:::mediaconvert:createJob.sync",
                                 "arn:aws:states:::sagemaker:createEndpoint",
                                 "arn:aws:states:::sagemaker:createEndpointConfig",
                                 "arn:aws:states:::sagemaker:createHyperParameterTuningJob",

--- a/src/snippets/states.json
+++ b/src/snippets/states.json
@@ -54,6 +54,24 @@
         ],
         "description": "Code snippet for an EventBridge Task state.\n\nCalls the Amazon EventBridge PutEvents API to send a custom event to an event bus."
 	},
+    {
+        "name": "MediaConvert Task State",
+        "body": [
+            "\"${1:Create a MediaConvert Transcoding Job}\": {",
+            "\t\"Type\": \"Task\",",
+            "\t\"Resource\": \"arn:aws:states:::mediaconvert:createJob\",",
+            "\t\"Parameters\": {",
+            "\t\t\"Role\": \"${3:arn:aws:iam::ACCOUNT_ID:role/MyServiceRole}\",",
+            "\t\t\"Settings\": {",
+            "\t\t\t\"Inputs\": [],",
+            "\t\t\t\"OutputGroups\": []",
+            "\t\t}",
+            "\t},",
+            "\t\"Next\": \"${2:NextState}\"",
+            "}"
+        ],
+        "description": "Code snippet for an MediaConvert Create Job Task state.\n\nCalls the AWS MediaConvert CreateJob API to create a Transcoding Job."
+	},
 	{
         "name": "SNS Task State",
         "body": [

--- a/src/tests/yamlCompletion.test.ts
+++ b/src/tests/yamlCompletion.test.ts
@@ -306,6 +306,7 @@ const stateSnippetLabels = [
     'Pass State',
     'Lambda Task State',
     'EventBridge Task State',
+    'MediaConvert Task State',
     'SNS Task State',
     'Batch Task State',
     'ECS Task State',


### PR DESCRIPTION
Pull Request to add new code snippet for MediaConvert Create Job API.

*Description of changes:*
Added a Code Snippet for MediaConvert Task State
https://docs.aws.amazon.com/step-functions/latest/dg/connect-mediaconvert.html

Testing:
Modified package locally and tested using VS Code Support to see if user could create an MediaConvert Task state and visualize it.
https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/building-stepfunctions.html#building-stepfunctions-code-snippets

![image (8)](https://github.com/user-attachments/assets/46a2ca40-1934-4ebe-b534-c3b9a4831529)
![image (9)](https://github.com/user-attachments/assets/102a04bd-046b-4297-baf1-d6546e08496c)
![image (10)](https://github.com/user-attachments/assets/6df32ea4-05a3-4229-a941-bbf34db12b41)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.